### PR TITLE
fix(CI): need to wait longer for DB to be available

### DIFF
--- a/ci/start-db.sh
+++ b/ci/start-db.sh
@@ -2,5 +2,5 @@
 
 cd ${EXIST_DB_FOLDER}
 nohup bin/startup.sh &
-sleep 30
+sleep 60
 curl http://127.0.0.1:8080/exist


### PR DESCRIPTION
60 seconds might be a bit long, but automatic releases do fail because of this timing issue with the db not being up reliably after 30