### PR TITLE
fix(CI): disable cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ after_script:
 before_cache:
   - ci/teardown-db.sh
 
-cache:
-  directories:
-    - ~/.npm
-    - node_modules
-    - ${HOME}/exist
+# cache:
+#   directories:
+#     - ~/.npm
+#     - node_modules
+#     - ${HOME}/exist


### PR DESCRIPTION
see travis-ci/travis-ci#10113

disabling cache ain't ideal since it adds about 1 min per build, but seems the only way to keep running with node 6 for now. 

[no-cache](https://travis-ci.org/eXist-db/node-exist/builds/456329126) 
[with cache](https://travis-ci.org/eXist-db/node-exist/builds/456321974)