### PR TITLE
Improve package installation

### DIFF
--- a/components/app.js
+++ b/components/app.js
@@ -43,9 +43,9 @@ function upload (client, xarBuffer, xarName) {
  * @param {String} [customPackageRepoUrl] a different repository to resolve package dependencies
  * @returns {NormalizedQueryResult} the result of the action
  */
-function install (client, xarName, packageUri, customPackageRepoUrl) {
+function install (client, xarName, customPackageRepoUrl) {
   const publicRepoURL = customPackageRepoUrl || defaultPackageRepo
-  const queryOptions = { variables: { xarName, packageUri, publicRepoURL } }
+  const queryOptions = { variables: { xarPath: `/db/system/repo/${xarName}`, publicRepoURL } }
 
   return queries.readAll(client, installQueryString, queryOptions)
     .then(result => JSON.parse(result.pages.toString()))

--- a/components/app.js
+++ b/components/app.js
@@ -16,7 +16,7 @@ const documents = require('./documents')
 const xqueryPath = path.resolve(__dirname, '../xquery/')
 const installQueryString = fs.readFileSync(path.join(xqueryPath, 'install-package.xq'))
 const removeQueryString = fs.readFileSync(path.join(xqueryPath, 'remove-package.xq'))
-const defaultPackageRepo = 'http://exist-db.org/exist/apps/public-repo'
+const defaultPackageRepo = 'https://exist-db.org/exist/apps/public-repo'
 
 /**
  * Upload XAR package to an existdb instance

--- a/readme.md
+++ b/readme.md
@@ -293,13 +293,13 @@ by default.
 If you want to use a different repository provide the optional `customPackageRepoUrl`.
 
 ```js
-db.app.install(xarName, packageUri[, customPackageRepoUrl])
+db.app.install(xarName, [, customPackageRepoUrl])
 ```
 
 **Example:**
 
 ```js
-db.app.install('test-app.xar', 'http://exist-db.org/apps/test-app')
+db.app.install('test-app.xar')
   .then(result => console.log(result))
   .catch(error => console.error(error))
 ```

--- a/spec/tests/app.js
+++ b/spec/tests/app.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const test = require('tape')
 const app = require('../../components/app')
-const exist = require('../../index')
+const { connect } = require('../../index')
 
 test('app component exports install method', function (t) {
   t.equal(typeof app.install, 'function')
@@ -19,7 +19,7 @@ test('app component exports upload method', function (t) {
 })
 
 test('upload and install application XAR', function (t) {
-  const db = exist.connect(require('../db-connection'))
+  const db = connect(require('../db-connection'))
 
   const xarBuffer = fs.readFileSync('spec/files/test-app.xar')
   const xarName = 'test-app.xar'
@@ -37,7 +37,7 @@ test('upload and install application XAR', function (t) {
   })
 
   t.test('install app', function (st) {
-    db.app.install(xarName, packageUri)
+    db.app.install(xarName)
       .then(response => {
         if (!response.success) { return Promise.reject(response.error) }
         st.plan(3)
@@ -52,7 +52,7 @@ test('upload and install application XAR', function (t) {
   })
 
   t.test('re-install app', function (st) {
-    db.app.install(xarName, packageUri)
+    db.app.install(xarName)
       .then(response => {
         if (!response.success) { return Promise.reject(response.error) }
         st.plan(3)
@@ -77,11 +77,10 @@ test('upload and install application XAR', function (t) {
 })
 
 test('empty application XAR', function (t) {
-  const db = exist.connect(require('../db-connection'))
+  const db = connect(require('../db-connection'))
 
   const xarBuffer = Buffer.from('')
   const xarName = 'test-empty-app.xar'
-  const packageUri = 'http://exist-db.org/apps/test-empty-app'
 
   t.test('upload app', function (st) {
     st.plan(1)
@@ -91,7 +90,7 @@ test('empty application XAR', function (t) {
   })
 
   t.test('install app', function (st) {
-    db.app.install(xarName, packageUri)
+    db.app.install(xarName)
       .then(response => {
         if (!response.error.code) { return Promise.reject(response.error) }
         st.plan(3)

--- a/xquery/install-package.xq
+++ b/xquery/install-package.xq
@@ -1,23 +1,67 @@
 xquery version "3.1";
 
-declare variable $packageUri external;
-declare variable $xarName external;
+declare namespace expath="http://expath.org/ns/pkg";
+(: declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+declare option output:method "json";
+declare option output:media-type "application/json"; :)
+
+declare variable $xarPath external;
 declare variable $publicRepoURL external;
 
+
+declare function local:remove ($package-uri as xs:string) as xs:boolean {
+    (repo:undeploy($package-uri)/@result = "ok") and
+    repo:remove($package-uri)
+};
+
+declare function local:only-package-meta (
+    $path as xs:anyURI,
+    $type as xs:string,
+    $param as item()*
+) as xs:boolean {
+    $path = "expath-pkg.xml"
+};
+
+declare function local:pass-through-data (
+    $path as xs:anyURI,
+    $type as xs:string,
+    $data as item()?,
+    $param as item()*
+) {
+    $data
+};
+
+declare function local:get-package-meta ($xar-path as xs:string) {
+    compression:unzip(
+        util:binary-doc($xar-path),
+        local:only-package-meta#3, (),
+        local:pass-through-data#4, ()
+    )
+};
+
 try {
-    let $found := exists(repo:list()[. = $packageUri])
+    let $meta := local:get-package-meta($xarPath)
+
+    let $package-uri := $meta//expath:package/string(@name)
+    let $found := $package-uri = repo:list()
+
     let $removed := 
-        $found and
-        (repo:undeploy($packageUri)/@result = "ok") and
-        repo:remove($packageUri)
+        if ($found)
+        then local:remove($package-uri)
+        else ()
+
     let $can-install := not($found) or $removed
     let $installation :=
         if ($can-install)
-        then (repo:install-and-deploy-from-db(
-            "/db/system/repo/" || $xarName,
-            $publicRepoURL || "/modules/find.xql"
-        ))
-        else (error(xs:QName("installation-error"), "package could not be installed"))
+        then repo:install-and-deploy-from-db(
+            $xarPath,
+            $publicRepoURL || "/find"
+        )
+        else error(
+            xs:QName("installation-error"), 
+            "package could not be installed"
+        )
+
     let $installed := $installation/@result = "ok"
 
     return

--- a/xquery/remove-package.xq
+++ b/xquery/remove-package.xq
@@ -3,11 +3,13 @@ xquery version "3.1";
 declare variable $packageUri external;
 
 try {
-    let $found := exists(repo:list()[. = $packageUri])
-    let $removed := 
-        not($found) or
-        (repo:undeploy($packageUri)/@result = "ok") and
-        repo:remove($packageUri)
+    let $found := $packageUri = repo:list()
+    let $removed :=
+        if ($found)
+        then 
+            (repo:undeploy($packageUri)/@result = "ok") and
+            repo:remove($packageUri)
+        else true()
 
     return
         serialize(


### PR DESCRIPTION
Read the package URI from the XAR package that is installed.
Since not removing a package with the same URI, before installation leads to severe issues with an existdb instance this will help mitigate them, as the user does not have to know the package URI.

Additionally, dependencies are resolved using HTTPS by default.

BREAKING CHANGE:
The signature of the function `db.app.install` changes, as the packageUri parameter is no longer needed.