### PR TITLE
doc: improve exist-ls example script

### DIFF
--- a/spec/examples/exist-ls
+++ b/spec/examples/exist-ls
@@ -6,21 +6,23 @@ const db = exist.connect({ secure: false, port: 8080 })
 async function ls (collection) {
     try {
         const query = `
+        declare variable $collection external;
+
         (
-            xmldb:get-child-collections("${collection}"),
-            xmldb:get-child-resources("${collection}")
+            xmldb:get-child-collections($collection),
+            xmldb:get-child-resources($collection)
         )
             => (function ($collections) { array { $collections } })()
             => serialize(map { "method": "json" })
         `
-        const result = await db.queries.readAll(query, {})
+        const result = await db.queries.readAll(query, { variables: {collection} })
         const json = JSON.parse(result.pages.toString())
         console.log(json)
     }
     catch (e) {
         let message = e.faultString ? e.faultString : e.message
         console.error("Could not run query! Reason:", message)
-    } 
+    }
 }
 
 if (!process.argv[2]) {


### PR DESCRIPTION
Cleaner separation of concerns:

- The XQuery that is sent to the server uses a variable $collection
which is declared as external.
- The call to db.queries.readAll provides the value for this variable.