### PR TITLE
chore(ci): improve github actions setup

### DIFF
--- a/.github/actions/setup-existdb/action.yml
+++ b/.github/actions/setup-existdb/action.yml
@@ -1,0 +1,21 @@
+name: "Setup eXist-db"
+description: "Start an exist-db instance running in a docker container"
+inputs:
+  docker-tag:
+    description: "Tag of the existdb docker"
+    required: true
+    default: "release"
+
+runs:
+  using: "composite"
+  steps:
+    - id: setup
+      run: |
+        docker pull existdb/existdb:${{ inputs.docker-tag }}
+        docker create --name exist-ci -p 8080:8080 -p 8443:8443 existdb/existdb:${{ inputs.docker-tag }}
+        docker start exist-ci
+      shell: bash
+      # TODO this should rather be polling for a running container / a running service
+    - id: wait-to-exist
+      run: sleep 30
+      shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,34 +5,48 @@ on:
     branches:
       - master
 
+# Tests cannot run on windows due to issues with the windows server 2019 images 
+# the github action runners are using not being able to run linux docker images
+# https://github.com/actions/virtual-environments/issues/1143
+
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: ['10', '12', '14']
+        docker-tag: [latest, release, 4.7.1]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/setup-existdb
+        with:
+          docker-tag: ${{ matrix.docker-tag }}
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
   release:
-    name: Release
+    needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: '14'
 
-      - name: npm install and build
-        run:
+      - name: Release package to npmjs
+        run: |
           npm ci
-
-      - name: Pull docker image
-        run: docker pull existdb/existdb:release
-
-      - name: Build docker image
-        run: docker create --name exist-ci -p 8080:8080 -p 8443:8443 existdb/existdb:release
-
-      - name: Start docker image
-        run: docker start exist-ci
-
-      - name: Wait for existdb startup
-        run: sleep 30
-
-      - run: npm test
-      - run: npx semantic-release
+          npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,44 +1,35 @@
-name: test node-exist
+name: Test Pull Request
 
 on:
   pull_request:
-    branches: [ master, develop ]
+    branches: 
+      - master
 
-  push:
-    branches:
-      - develop
-
-  workflow_dispatch:
+# Tests cannot run on windows due to issues with the windows server 2019 images 
+# the github action runners are using not being able to run linux docker images
+# https://github.com/actions/virtual-environments/issues/1143
 
 jobs:
-  build:
-      runs-on: ubuntu-latest
-      strategy:
-        matrix:
-          node-version: [10.x, 12.x, 14.x]
-          docker-tag: [latest, release, 4.7.1]
-      steps:
-      - uses: actions/checkout@v2
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: ['10', '12', '14']
+        docker-tag: [latest, release, 4.7.1]
 
+    steps:
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/setup-existdb
+        with:
+          docker-tag: ${{ matrix.docker-tag }}
 
-      - name: npm install and build
+      - name: Install
         run: npm ci
 
-      - name: Pull docker image
-        run: docker pull existdb/existdb:${{ matrix.docker-tag }}
-
-      - name: Build docker image
-        run: docker create --name exist-ci -p 8080:8080 -p 8443:8443 existdb/existdb:${{ matrix.docker-tag }}
-
-      - name: Start docker image
-        run: docker start exist-ci
-
-      - name: Wait for existdb startup
-        run: sleep 30
-
-      - name: npm test
+      - name: Test
         run: npm test


### PR DESCRIPTION
- re-use setup-existdb action in both test and release definitions
- add OS to matrix but limit to ubuntu for now
- release job depends on test now