### PR TITLE
Fix: readOptionsFromEnv

### DIFF
--- a/components/connection.js
+++ b/components/connection.js
@@ -82,7 +82,7 @@ function connect (options) {
 function readOptionsFromEnv () {
   const environmentOptions = {}
 
-  if (process.env.EXISTDB_USER && process.env.EXISTDB_PASS) {
+  if (process.env.EXISTDB_USER && 'EXISTDB_PASS' in process.env) {
     environmentOptions.basic_auth = {
       user: process.env.EXISTDB_USER,
       pass: process.env.EXISTDB_PASS

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "promise based interaction with eXist DB's XML-RPC API",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/standard && node_modules/.bin/tape spec/tests/*.js",
+    "test": "standard && tape spec/tests/*.js",
     "semantic-release": "semantic-release",
     "travis-deploy-once": "travis-deploy-once"
   },

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # node-exist
 
-![example branch parameter](https://github.com/exist-db/node-exist/actions/workflows/semantic-release.yml/badge.svg)
+![semantic release status](https://github.com/exist-db/node-exist/actions/workflows/semantic-release.yml/badge.svg)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 Mostly a shallow wrapper for [eXist's XML-RPC API](http://exist-db.org/exist/apps/doc/devguide_xmlrpc.xml).
@@ -66,7 +66,7 @@ uploadAndParse('/db/apps/test-file.xml', Buffer.from('<root/>'))
 ```
 
 You can also have a look at the 
-[examples](https://github.com/eXist-db/node-exist/tree/master/spec/examples) for more use-cases.
+[examples](spec/examples) for more use-cases.
 
 ## Configuration
 

--- a/spec/tests/readenv.js
+++ b/spec/tests/readenv.js
@@ -1,0 +1,66 @@
+const test = require('tape')
+
+const { readOptionsFromEnv } = require('../../index')
+
+test('connection options from environment', function (t) {
+  const optionsFromEnv = readOptionsFromEnv()
+  const userIsSet = process.env.EXISTDB_USER && process.env.EXISTDB_PASS
+  const serverIsSet = 'EXISTDB_SERVER' in process.env
+
+  if (serverIsSet) {
+    const { hostname, port, protocol } = new URL(process.env.EXISTDB_SERVER)
+    t.equal(optionsFromEnv.port, port)
+    t.equal(optionsFromEnv.secure, protocol === 'https:')
+    t.equal(optionsFromEnv.host, hostname)
+  } else {
+    t.false('port' in optionsFromEnv)
+    t.false('secure' in optionsFromEnv)
+    t.false('host' in optionsFromEnv)
+  }
+
+  if (userIsSet) {
+    t.ok(optionsFromEnv.basic_auth)
+    t.equal(optionsFromEnv.basic_auth.user, process.env.EXISTDB_USER)
+    t.equal(optionsFromEnv.basic_auth.pass, process.env.EXISTDB_PASS)
+  } else {
+    t.false('basic_auth' in optionsFromEnv)
+  }
+
+  t.end()
+})
+
+test('test user set in env', function (t) {
+  process.env.EXISTDB_USER = 'test'
+  process.env.EXISTDB_PASS = 'test'
+  const optionsFromEnv = readOptionsFromEnv()
+  t.ok(optionsFromEnv.basic_auth)
+  t.equal(optionsFromEnv.basic_auth.user, 'test')
+  t.equal(optionsFromEnv.basic_auth.pass, 'test')
+  t.end()
+})
+
+test('test user set in env with empty password', function (t) {
+  process.env.EXISTDB_USER = 'test'
+  process.env.EXISTDB_PASS = ''
+  const optionsFromEnv = readOptionsFromEnv()
+  t.ok(optionsFromEnv.basic_auth)
+  t.equal(optionsFromEnv.basic_auth.user, 'test')
+  t.equal(optionsFromEnv.basic_auth.pass, '')
+  t.end()
+})
+
+test('empty user set in env', function (t) {
+  process.env.EXISTDB_USER = ''
+  process.env.EXISTDB_PASS = 'test1234'
+  const optionsFromEnv = readOptionsFromEnv()
+  t.false('basic_auth' in optionsFromEnv)
+  t.end()
+})
+
+test('only user set in env', function (t) {
+  process.env.EXISTDB_USER = 'test'
+  delete process.env.EXISTDB_PASS
+  const optionsFromEnv = readOptionsFromEnv()
+  t.notOk(optionsFromEnv.basic_auth)
+  t.end()
+})


### PR DESCRIPTION
An empty password set in ENV would cause the basic_auth not to be returned by readOptionsFromEnv

It's also tested now :)