### PR TITLE
Add CLI tool exist-tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "lodash.assign": "^4.0.2",
         "mime": "^2.3.1",
-        "xmlrpc": "^1.3.1"
+        "xmlrpc": "^1.3.1",
+        "yargs": "16.2.0"
       },
       "bin": {
         "exist-install": "spec/examples/exist-install",
         "exist-ls": "spec/examples/exist-ls",
+        "exist-tree": "spec/examples/exist-tree",
         "exist-upload": "spec/examples/exist-upload"
       },
       "devDependencies": {
@@ -380,8 +382,7 @@
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -515,7 +516,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -524,7 +524,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
       "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-      "dev": true,
       "dependencies": {
         "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
@@ -540,7 +539,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -551,8 +549,7 @@
     "node_modules/ansi-styles/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/ansicolors": {
       "version": "0.3.2",
@@ -966,7 +963,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1455,8 +1451,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -1640,7 +1635,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2511,7 +2505,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3035,7 +3028,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7576,7 +7568,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8220,7 +8211,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8413,7 +8403,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.0"
       },
@@ -9103,7 +9092,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9177,7 +9165,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -9201,7 +9188,6 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -9219,7 +9205,6 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -9526,8 +9511,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -9629,14 +9613,12 @@
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
       "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-      "dev": true,
       "requires": {
         "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
@@ -9646,7 +9628,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -9654,8 +9635,7 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         }
       }
     },
@@ -9966,7 +9946,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -10355,8 +10334,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -10500,8 +10478,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -11153,8 +11130,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -11531,8 +11507,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -14831,8 +14806,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "resolve": {
       "version": "1.12.0",
@@ -15318,7 +15292,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -15456,7 +15429,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -15988,7 +15960,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -16039,8 +16010,7 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -16058,7 +16028,6 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -16072,8 +16041,7 @@
     "yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "travis-deploy-once": "travis-deploy-once"
   },
   "bin": {
+    "exist-tree": "spec/examples/exist-tree",
     "exist-ls": "spec/examples/exist-ls",
     "exist-upload": "spec/examples/exist-upload",
     "exist-install": "spec/examples/exist-install"
@@ -28,7 +29,8 @@
     "rpc",
     "api",
     "promise",
-    "lib"
+    "lib",
+    "cli"
   ],
   "repository": {
     "type": "git",
@@ -50,7 +52,8 @@
   "dependencies": {
     "lodash.assign": "^4.0.2",
     "mime": "^2.3.1",
-    "xmlrpc": "^1.3.1"
+    "xmlrpc": "^1.3.1",
+    "yargs": "16.2.0"
   },
   "version": "0.0.0-development"
 }

--- a/spec/examples/exist-tree
+++ b/spec/examples/exist-tree
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+const {argv} = require('process'); // eslint-disable-line node/prefer-global/process
+
+const {connect} = require('../../index')
+
+// read connection options from ENV
+const connectionOptions = require('../connection')
+
+// the more complex a query gets that is executed
+// the more sense it makes to read it from a file
+// see db.app.install and how it uses xquery/install-package.xq 
+const query = `xquery version "3.1";
+
+declare variable $collection external;
+declare variable $level external;
+
+declare function local:get-descendant-resources ($collection, $current-level) {
+    for $sc in xmldb:get-child-collections($collection)
+    let $p := concat($collection, "/", $sc)
+    return
+        map {
+        "type": "collection",
+        "name": $sc,
+        "path": $p,
+        "children": array {
+            if ($level = 0 or $level > $current-level)
+            then (local:get-descendant-resources($p, $current-level + 1))
+            else ()
+            ,
+            if ($level = 0 or $level > $current-level)
+            then (
+            for $r in xmldb:get-child-resources($p)
+            return map { 
+                "type": "resource",
+                "name": $r,
+                "path": concat($p, "/", $r)
+            }
+            )
+            else ()
+        }
+    }
+};
+
+declare function local:tree ($base) {
+    map {
+        "type": "collection",
+        "name": replace($base, ".*/(.+)?", "$1"),
+        "path": $base,
+        "children": array {
+            local:get-descendant-resources($base, 1)
+        }
+    }
+};
+
+serialize(local:tree($collection), map{"method": "json"})
+`
+
+const FILL  = '│  ';
+const ITEM  = '├─ ';
+const LAST  = '└─ ';
+const EMPTY = '   ';
+
+function renderItem (name, indent, last, root) {
+    if (root) {
+        return name
+    }
+    if (last) {
+        return indent + LAST + name
+    }
+    return indent + ITEM + name
+}
+
+function getNextIndent (indent, last, root) {
+    if (root) {
+        return indent
+    }
+    if (last) {
+        return indent + EMPTY
+    }
+    return indent + FILL
+}
+
+function renderTree(json, level=0, indent='', last=false) {
+    const item = renderItem(json.name, indent, last, level === 0)
+    console.log(item)
+
+    if (!json.children || json.type === "resource") {
+        return
+    }
+
+    const nextLevel = level + 1
+    const nextIndent = getNextIndent(indent, last, level === 0)
+    const length = json.children.length -1
+    for (const i in json.children) {
+        const nextItem = json.children[i]
+        const isLast = Boolean(length == i)
+        renderTree(nextItem, nextLevel, nextIndent, isLast)
+    }
+}
+
+async function tree (collection, level) {
+    try {
+        const db = connect(connectionOptions)
+        const result = await db.queries.readAll(query, { variables: {collection, level} })
+        const json = JSON.parse(result.pages.toString())
+        renderTree(json)
+        return 0
+    }
+    catch (e) {
+        let message = e.faultString ? e.faultString : e.message
+        console.error("Could not run query! Reason:", message)
+        return 1
+    }
+}
+
+async function run() {
+    const cli = require('yargs')
+    .command('$0', 'Upload resources into an exist-db', (yargs) => {
+      yargs.demandCommand(1, 1).usage(`List a collection and its contents as a tree
+  
+  Usage:
+    exist-tree [options] collection`);
+    })
+    // .option('d', {alias: 'dry-run', describe: 'Show what would be uploaded', type: 'boolean', group: 'Options'})
+    .option('l', {alias: 'level', describe: 'The maximum depth of the tree. Setting this to zero will output the complete tree.', type: Number, default: 0, group: 'Options'})
+    .option('h', {alias: 'help', group: 'Options'})
+    .option('v', {alias: 'version', group: 'Options'})
+    .strict(false)
+    .exitProcess(false);
+  
+    try {
+      const parsed = cli.parse(argv.slice(2))
+      if (Boolean(parsed.help) || Boolean(parsed.version)) {
+        return 0
+      }
+      const {level} = parsed
+
+      if (typeof level !== 'number' || level < 0) {
+        console.error('Invalid value for option "level"; must be an integer greater than zero.')
+        return 1
+      }
+  
+      const collection = parsed._
+      return tree(collection, level)
+    }
+    catch (error) {
+      if (error.name !== 'YError') {
+        console.error(error)
+      }
+      return 1
+    }
+  }
+  
+run()
+    .then((exitCode) => {
+        process.exitCode = exitCode
+    })
+    .catch((error) => {
+        console.error(error)
+        process.exitCode = 1
+    })
+  

--- a/spec/examples/readme.md
+++ b/spec/examples/readme.md
@@ -1,6 +1,7 @@
 # node-exist Command Line Scripts
 
 - `exist-ls` list the contents of a collection in exist-db
+- `exist-tree` list the contents of a collection in exist-db as a tree
 - `exist-upload` upload a file to an exist-db instance
 - `exist-install` upload and install a package into an existdb-instance
 
@@ -36,7 +37,21 @@ dotenv(-cli) is a small script that allows you to read environment variables fro
 
 prepend command line script with `dotenv` in the folder you created the .env file in
 
-Example (here in the root of the cloned repository):
+Example
+
+If you installe node-exist globally (`npm install -g @existdb/node-exist`)
+
+```bash
+dotenv exist-ls /db/apps
+```
+
+If you installed node-exist as a local package (npm dependency)
+
+```bash
+dotenv node_module/.bin/exist-ls /db/apps
+```
+
+If you cloned this repository
 
 ```bash
 dotenv spec/examples/exist-ls /db/apps


### PR DESCRIPTION
This new command line tool allows you to list the contents of any 
collection in your database as a tree.
The option `-l` or `--level` controls how many levels down the tree will
traverse.

Example:
```bash
spec/examples/exist-tree --level 2 /db
```

On a fresh existdb instance this will output:
```
db
├─ system
│  ├─ config
│  ├─ security
│  ├─ plugins
│  └─ repo
└─ apps
   ├─ packageservice
   ├─ dashboard
   ├─ eXide
   ├─ doc
   ├─ fundocs
   └─ monex
```