### PR TITLE
feat(examples): exist-ls roughly mimics the ls command

### DIFF
--- a/spec/examples/exist-ls
+++ b/spec/examples/exist-ls
@@ -1,53 +1,298 @@
 #!/usr/bin/env node
 
-const {connect} = require('../../index')
+const { connect } = require("../../index");
+const { argv } = require("process"); // eslint-disable-line node/prefer-global/process
 
 // read connection options from ENV
-const connectionOptions = require('../connection')
+const connectionOptions = require("../connection");
 
 // the more complex a query gets that is executed
 // the more sense it makes to read it from a file
-// see db.app.install and how it uses xquery/install-package.xq 
+// see db.app.install and how it uses xquery/install-package.xq
 const query = `xquery version "3.1";
-declare variable $collection external;
-declare function local:map-child ($child, $type) {
+declare variable $collection as xs:string external;
+declare variable $glob as xs:string external;
+declare variable $extended as xs:boolean external;
+
+declare function local:glob-to-regex ($glob as xs:string) as xs:string {
+    let $pattern := 
+        $glob
+        => replace("\\.", "\\\\.")
+        => replace("(\\*|\\?)", ".$1")
+
+    return concat("^", $pattern, "$")
+};
+
+declare function local:get-item-info ($type as xs:string, $child as xs:string) as map(*) {
     map {
         "type": $type,
         "name": $child
     }
 };
 
-(
-    xmldb:get-child-collections($collection)
-    => for-each(local:map-child(?, "collection")),
-    xmldb:get-child-resources($collection)
-    => for-each(local:map-child(?, "resource"))
+declare function local:get-extended-info ($type as xs:string, $child as xs:string) as map(*) {
+    let $path := xs:anyURI($collection || "/" || $child)
+    let $perm := sm:get-permissions($path)/sm:permission
+    let $e := 
+        if ($type = "collection")
+        then map {
+            "size": 0,
+            "modified": xmldb:created($path)
+        }
+        else map {
+            "size": xmldb:size($collection, $child),
+            "modified": xmldb:last-modified($collection, $child)
+        }
+
+    return map:merge((
+        map {
+            "type": $type,
+            "name": $child,
+            "mode": $perm/@mode/string(),
+            "owner": $perm/@owner/string(),
+            "group": $perm/@group/string()
+        },
+        $e
+    ))
+};
+
+declare function local:get-mapping-function ($type as xs:string, $glob as xs:string?) as function(xs:string) as map(*) {
+    if ($glob = ("*", "**") and $extended)
+    then (
+        local:get-extended-info($type, ?)
+    )
+    else if ($glob = ("*", "**"))
+    then (
+        local:get-item-info($type, ?)
+    )
+    else (
+        let $pattern := local:glob-to-regex($glob)
+        let $get-info-for :=
+            if ($extended)
+            then local:get-extended-info($type, ?)
+            else local:get-item-info($type, ?)
+
+        return
+            function ($child as xs:string) {
+                if (matches($child, $pattern))
+                then $get-info-for($child)
+                else ()
+            }
+    )
+
+};
+
+
+if (xmldb:collection-available($collection))
+then (
+    let $list := array {
+        for-each(
+            xmldb:get-child-collections($collection),
+            local:get-mapping-function("collection", $glob)
+        ),
+        for-each(
+            xmldb:get-child-resources($collection),
+            local:get-mapping-function("resource", $glob)
+        )
+    }
+    return serialize($list, map { "method": "json" })
 )
-    => (function ($children) { array { $children } })()
-    => serialize(map { "method": "json" })
-`
+else serialize(
+    map { "error": 'Collection "' || $collection || '" not found!' }, 
+    map { "method": "json" }
+)
+`;
 
-async function ls (connectionOptions, collection) {
-    try {
-        const db = connect(connectionOptions)
-        const result = await db.queries.readAll(query, { variables: {collection} })
-        const json = JSON.parse(result.pages.toString())
-        console.log(json)
-    }
-    catch (e) {
-        let message = e.faultString ? e.faultString : e.message
-        console.error("Could not run query! Reason:", message)
-        process.exit(1)
-    }
+const consoleColors = new Map([
+  ["Reset", "\x1b[0m"],
+  ["Bright", "\x1b[1m"],
+  ["Dim", "\x1b[2m"],
+  ["Underscore", "\x1b[4m"],
+  ["Blink", "\x1b[5m"],
+  ["Reverse", "\x1b[7m"],
+  ["Hidden", "\x1b[8m"],
+
+  ["FgBlack", "\x1b[30m"],
+  ["FgRed", "\x1b[31m"],
+  ["FgGreen", "\x1b[32m"],
+  ["FgYellow", "\x1b[33m"],
+  ["FgBlue", "\x1b[34m"],
+  ["FgMagenta", "\x1b[35m"],
+  ["FgCyan", "\x1b[36m"],
+  ["FgWhite", "\x1b[37m"],
+
+  ["BgBlack", "\x1b[40m"],
+  ["BgRed", "\x1b[41m"],
+  ["BgGreen", "\x1b[42m"],
+  ["BgYellow", "\x1b[43m"],
+  ["BgBlue", "\x1b[44m"],
+  ["BgMagenta", "\x1b[45m"],
+  ["BgCyan", "\x1b[46m"],
+  ["BgWhite", "\x1b[47m"],
+]);
+
+const cc = (name) => consoleColors.get(name);
+
+const initialPaddings = new Map([
+  ["padOwner", 0],
+  ["padGroup", 0],
+  ["padSize", 4],
+])
+
+const padReducer = (res, next) => {
+  if (res.get("padGroup") < next.group.length) {
+    res.set("padGroup", next.group.length);
+  }
+  if (res.get("padOwner") < next.owner.length) {
+    res.set("padOwner", next.owner.length);
+  }
+  if (res.get("padSize") < next.size.toFixed().length) {
+    res.set("padSize", next.size.toFixed().length);
+  }
+  return res;
+};
+
+const getPaddings = (list) => list.reduce(padReducer, initialPaddings);
+
+const timeFormat = {
+  timeStyle: "short"
+}
+const dateFormat = {
+  month: "short",
+  day: "numeric",
+};
+
+const currentYear = (new Date()).getFullYear()
+
+function formatDateTime(xsDateTime) {
+  const date = new Date(xsDateTime)
+  const year = date.getFullYear()
+  const dayMonth = date.toLocaleDateString("iso", dateFormat)
+  if (year < currentYear) {
+    return dayMonth + " " + year
+  }
+  return dayMonth + " " + date.toLocaleDateString("iso", timeFormat)
 }
 
-if (!process.argv[2]) {
-    console.log("Usage: exist-ls [collection]")
-    console.log("Example: exist-ls /db/apps")
-    process.exit(9)
+function formatName(item, color) {
+  if (!color) {
+    return item.name;
+  }
+  if (item.type === "resource") {
+    return item.name;
+  }
+  return cc("Bright") + cc("FgCyan") + item.name + cc("Reset");
 }
 
-const dbPath = process.argv[2] 
+function renderList(list, color) {
+  for (let item of list) {
+    console.log(formatName(item, color));
+  }
+}
 
-// run query
-ls(connectionOptions, dbPath)
+function renderExtendedListItem(item, paddings, color) {
+  console.log(
+    item.mode,
+    item.owner.padStart(paddings.get("padOwner")),
+    item.group.padStart(paddings.get("padGroup")),
+    item.size.toFixed().padStart(paddings.get("padSize")),
+    formatDateTime(item.modified),
+    formatName(item, color)
+  );
+}
+
+function renderExtendedList(list, noColor) {
+  const paddings = getPaddings(list);
+  for (let item of list) {
+    renderExtendedListItem(item, paddings, noColor);
+  }
+}
+
+async function ls(collection, options) {
+  try {
+    const db = connect(connectionOptions);
+    const {glob, color, extended} = options 
+    const result = await db.queries.readAll(query, {
+      variables: { collection, glob, extended },
+    });
+    const json = JSON.parse(result.pages.toString());
+    if (json.error) {
+      throw Error(json.error);
+    }
+    if (extended) {
+      renderExtendedList(json, color);
+      return;
+    }
+    renderList(json, color);
+  } catch (e) {
+    let message = e.faultString ? e.faultString : e.message;
+    console.error(message);
+    process.exit(1);
+  }
+}
+
+async function run() {
+  const cli = require("yargs")
+    .command("$0", "List connection contents", (yargs) => {
+      yargs.demandCommand(1, 1).usage(`List connection contents
+  
+  Usage:
+    exist-ls [options] collection`);
+    })
+    .option("G", {
+      alias: "color",
+      describe: "Color the output",
+      default: false,
+      type: "boolean",
+      group: "Options",
+    })
+    .option("l", {
+      alias: "extended",
+      describe: "Display more information for each item",
+      default: false,
+      type: "boolean",
+      group: "Options",
+    })
+    .option("g", {
+      alias: "glob",
+      describe:
+        "Include only collection names and resources whose name match the pattern.",
+      type: String,
+      default: "*",
+      group: "Options",
+    })
+    .option("h", { alias: "help", group: "Options" })
+    .option("v", { alias: "version", group: "Options" })
+    .strict(false)
+    .exitProcess(false);
+
+  try {
+    const parsed = cli.parse(argv.slice(2));
+    if (Boolean(parsed.help) || Boolean(parsed.version)) {
+      return 0;
+    }
+
+    const { glob, color, extended } = parsed;
+    if (typeof glob !== "string") {
+      console.error('Invalid value for option "glob"; must be a string.');
+      return 1;
+    }
+
+    const collection = parsed._;
+    return ls(collection, { glob, color, extended });
+  } catch (error) {
+    if (error.name !== "YError") {
+      console.error(error);
+    }
+    return 1;
+  }
+}
+
+run()
+  .then((exitCode) => {
+    process.exitCode = exitCode;
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
This PR introduces new flags and extended capability to the existing CLI tool `exist-ls`

- `--extended`,`-l`: output mode, owner, group, mtime in addtition to
  the name
- `--glob`, `-g` filter list to only include items that match the given
  glob-pattern. Only * and ? are supported at the moment
- `--color`, `-G` color the output

Example

```bash
$ spec/examples/exist-ls -l /db
rwxr-xr-x SYSTEM dba    0 25 Jan 16:49 system
rwxr-xr-x SYSTEM dba    0 25 Jan 16:49 apps
```