### PR TITLE
feat(collections): existsAndCanOpen

### DIFF
--- a/components/collections.js
+++ b/components/collections.js
@@ -18,9 +18,17 @@ function read (client, name) {
   return client.promisedMethodCall('getCollectionDesc', [name])
 }
 
+// convenience function
+// throws an exception if and only if
+// the collection exists but cannot be written by the user
+function existsAndCanOpen (client, name) {
+  return client.promisedMethodCall('existsAndCanOpenCollection', [name])
+}
+
 module.exports = {
   create,
   remove,
   describe,
-  read
+  read,
+  existsAndCanOpen
 }

--- a/readme.md
+++ b/readme.md
@@ -283,6 +283,19 @@ db.collections.describe(collectionPath)
 db.collections.read(collectionPath)
 ```
 
+#### existsAndCanOpen
+
+This function checks if the collection exists and if it does, if the current user can access it.
+
+- returns `true` if the collection exists and the current user can open it
+- returns `false` if the collection does not exist
+- throws an exception if the collection exists but the current user cannot
+  access it
+
+```js
+db.collections.existsAndCanOpen(collectionPath)
+```
+
 ### App
 
 Status: working

--- a/spec/tests/collections.js
+++ b/spec/tests/collections.js
@@ -1,6 +1,10 @@
 const test = require('tape')
 const { connect } = require('../../index')
 const connectionOptions = require('../connection')
+const asGuest = Object.assign({},
+  connectionOptions,
+  { basic_auth: { user: 'guest', pass: 'guest' } }
+)
 
 test('get collection info', function (t) {
   const db = connect(connectionOptions)
@@ -60,6 +64,71 @@ test('remove collection', function (t) {
     })
     .catch(function (e) {
       t.fail(e, 'remove failed')
+      t.end()
+    })
+})
+
+test('collection exists and guest cannot open it', function (t) {
+  const db = connect(asGuest)
+  db.collections.existsAndCanOpen('/db/system/security')
+    .then(function () {
+      t.fail()
+      t.end()
+    })
+    .catch(function (e) {
+      t.ok(e, '/db/system/security exists and user guest cannot access it')
+      t.end()
+    })
+})
+
+test('collection exists and guest can open it', function (t) {
+  const db = connect(asGuest)
+  db.collections.existsAndCanOpen('/db/apps/dashboard')
+    .then(function (success) {
+      t.true(success, '/db/apps/dashboard exists and user guest can access it')
+      t.end()
+    })
+    .catch(function (e) {
+      t.fail(e)
+      t.end()
+    })
+})
+
+test('collection does not exist (guest)', function (t) {
+  const db = connect(asGuest)
+  db.collections.existsAndCanOpen('/db/apps/asdf')
+    .then(function (success) {
+      t.false(success, '/db/apps/asdf does not exist')
+      t.end()
+    })
+    .catch(function (e) {
+      t.fail(e)
+      t.end()
+    })
+})
+
+test('collection exists and admin can open it', function (t) {
+  const db = connect(connectionOptions)
+  db.collections.existsAndCanOpen('/db/system/security')
+    .then(function (success) {
+      t.true(success)
+      t.end()
+    })
+    .catch(function (e) {
+      t.fail(e)
+      t.end()
+    })
+})
+
+test('collection does not exist (admin)', function (t) {
+  const db = connect(connectionOptions)
+  db.collections.existsAndCanOpen('/db/apps/asdf')
+    .then(function (success) {
+      t.false(success, '/db/apps/asdf does not exist')
+      t.end()
+    })
+    .catch(function (e) {
+      t.fail(e)
       t.end()
     })
 })


### PR DESCRIPTION
Implements a call to collectionExistsAndCanOpen function
provided by the XML RPC API of existdb.

It will
- return `true` if the collection exists and the current user can open it
- return `false` if the collection does not exist
- **throws** an exception if the collection exists
  but the current user cannot access it