### PR TITLE
fix(examples): render padded year in exist-ls extended

### DIFF
--- a/spec/examples/exist-ls
+++ b/spec/examples/exist-ls
@@ -170,7 +170,7 @@ function formatDateTime(xsDateTime) {
   const month = date.toLocaleDateString("iso", dateFormat)
   const day = date.getDate().toString().padStart(3)
   if (year < currentYear) {
-    return month + day + year.padStart(6)
+    return month + day + year.toString().padStart(6)
   }
   const time = date.toLocaleDateString("iso", timeFormat).padStart(6)
   return month + day + time


### PR DESCRIPTION
Older elements will display the year instead of the time they were last
modified.
In order for the year to be padded appropriately it is now converted to
a string.