### PR TITLE
fix(examples): exist-install working again

### DIFF
--- a/spec/examples/exist-install
+++ b/spec/examples/exist-install
@@ -13,17 +13,30 @@ function usage() {
   process.exit(9)
 }
 
+function serverName(db) {
+  const {isSecure, options} = db.client
+
+  const protocol = `http${isSecure ? 's' : ''}:` 
+  const isStdPort =
+      (isSecure && options.port === 443) ||
+      (!isSecure && options.port === 80)
+
+  if (isStdPort) {
+    return `${protocol}//${options.host}`
+  }
+  return `${protocol}//${options.host}:${options.port}`
+}
+
 async function install (connectionOptions, localFilePath) {
   try {
     const db = connect(connectionOptions)
     const xarName = basename(localFilePath)
     const contents = readFileSync(localFilePath)
-    const msg = `Install ${xarName} on ${hostname}:\n`
-    process.stdout.write(msg)
+
+    process.stdout.write(`Install ${xarName} on ${serverName(db)}\n`)
 
     process.stdout.write("uploading...")
     const uploadResult = await db.app.upload(contents, xarName)
-    
     if (!uploadResult.success) {
       throw new Error(uploadResult.error)
     }
@@ -41,7 +54,8 @@ async function install (connectionOptions, localFilePath) {
 
     process.stdout.clearLine()
     process.stdout.cursorTo(0)
-    process.stdout.write("✔︎ installed\n");
+    const installationMessage = installResult.result.update ? "updated" : "installed"
+    process.stdout.write(`✔︎ ${installationMessage}\n`);
 
     return 0
   }


### PR DESCRIPTION
- now also displays `updated` when a previous installation was found
- improved _and fixed_ display of hostname, now displays server URL with
  protocol and non-standard port