### PR TITLE
feat(examples): first implementation of exist-exec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "lodash.assign": "^4.0.2",
         "mime": "^3.0.0",
         "xmlrpc": "^1.3.1",
-        "yargs": "16.2.0"
+        "yargs": "^17.3.1"
       },
       "bin": {
         "exist-install": "spec/examples/exist-install",
@@ -7054,6 +7054,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/semantic-release/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -8180,28 +8198,37 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "engines": {
+        "node": ">=12"
       }
     }
   },
@@ -13373,6 +13400,21 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
         }
       }
     },
@@ -14242,23 +14284,31 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "21.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+        }
       }
     },
     "yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "exist-tree": "spec/examples/exist-tree",
     "exist-ls": "spec/examples/exist-ls",
     "exist-upload": "spec/examples/exist-upload",
-    "exist-install": "spec/examples/exist-install"
+    "exist-install": "spec/examples/exist-install",
+    "exist-exec": "spec/examples/exist-exec"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash.assign": "^4.0.2",
     "mime": "^3.0.0",
     "xmlrpc": "^1.3.1",
-    "yargs": "16.2.0"
+    "yargs": "^17.3.1"
   },
   "version": "0.0.0-development"
 }

--- a/spec/examples/exist-exec
+++ b/spec/examples/exist-exec
@@ -80,7 +80,7 @@ Usage:
   
     try {
       const parsed = cli.parse(argv.slice(2))
-      if (Boolean(parsed.help) || Boolean(parsed.version)) {
+      if (Boolean(parsed.help)) {
         return 0
       }
       const {file, bind} = parsed

--- a/spec/examples/exist-exec
+++ b/spec/examples/exist-exec
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+const {argv} = require('process'); // eslint-disable-line node/prefer-global/process
+const {connect} = require('../../index')
+const {readFileSync, fstat} = require("fs")
+
+// read connection options from ENV
+const connectionOptions = require('../connection')
+
+async function execute(db, query, variables) {
+    const result = await db.queries.readAll(query, { variables })
+    console.log(result.pages.toString())
+    return 0
+}
+
+async function run() {
+    const cli = require('yargs')
+    .command('$0', 'Execute queries in an exist-db', (yargs) => {
+      yargs.demandCommand(0, 1).usage(`Execute queries in an exist-db
+  
+  Usage:
+    exist-exec [options] [query]`);
+    })
+    .option('f', {alias: 'file', describe: 'Read query File', type: 'string', default: '', group: 'Options'})
+    .option('b', {alias: 'bound-variables', describe: 'bound variables as JSON', type: 'string', coerce: JSON.parse, default: {}, group: 'Options'})
+    .option('h', {alias: 'help', group: 'Options'})
+    .option('v', {alias: 'version', group: 'Options'})
+    .strict(false)
+    .exitProcess(false);
+  
+    try {
+      const parsed = cli.parse(argv.slice(2))
+      if (Boolean(parsed.help) || Boolean(parsed.version)) {
+        return 0
+      }
+      const {file, boundVariables} = parsed
+      const query = parsed._[0]
+
+      if (file === '' && !query) {
+        console.error('nothing to do')
+        return 1
+      }
+
+      if (file !== '' && query && query !== '') {
+        console.error('Cannot use both query string and query file')
+        return 1
+      }
+
+      const db = connect(connectionOptions)
+
+      if (file !== '') {
+        const xqf = readFileSync(file)
+        return await execute(db, xqf, boundVariables)
+      }
+
+      return await execute(db, query, boundVariables)
+    }
+    catch (error) {
+        if (
+            error.code === 'EPROTO' ||
+            error.code === 'ECONNREFUSED' ||
+            error.code === 'ECONNRESET'
+        ) {
+            console.error(`Could not connect to DB at ${serverName(db)} - Reason: ${error.code}`)
+            return 1
+        }
+        if (error.name !== 'YError') {
+            const msg = error.message ? error.message : error.faultString ? error.faultString : error
+            console.error(msg)
+        }
+        return 1
+    }
+  }
+  
+run()
+    .then((exitCode) => {
+        process.exitCode = exitCode
+    })
+    .catch((error) => {
+        console.error(error)
+        process.exitCode = 1
+    })

--- a/spec/examples/exist-exec
+++ b/spec/examples/exist-exec
@@ -5,8 +5,15 @@ const {connect} = require('../../index')
 const {readFileSync} = require("fs")
 
 // read connection options from ENV
-const connectionOptions = require('../connection')
+const connectionOptions = require('../connection');
+const NodeExist = require('../../index');
 
+/**
+ * parse bindings
+ * '-' will read bindings from standard input
+ * @param {'-'|JSON} raw JSON string or '-'
+ * @returns {object} parsed variable bindings
+ */
 function parseVars (raw) {
     let stringified = raw
     if (raw === '-') {
@@ -18,6 +25,13 @@ function parseVars (raw) {
     return {}
 }
 
+/**
+ * get query from file or passed string
+ * 
+ * @param {string} file path to query file
+ * @param {string} query query string
+ * @returns {string|Buffer}
+ */
 function getQuery (file, query) {
     const hasQueryFile = file && file !== ''
     const hasQueryString = query && query !== ''
@@ -50,6 +64,14 @@ function getQuery (file, query) {
     return readFileSync(path, 'utf-8')
 }
 
+/**
+ * query db, output to standard out
+ * 
+ * @param {NodeExist.BoundModules} db bound NodeExist modules
+ * @param {string|Buffer} query the query to execute
+ * @param {object} variables the bound variables
+ * @returns {Number}
+ */
 async function execute(db, query, variables) {
     const result = await db.queries.readAll(query, { variables })
     console.log(result.pages.toString())
@@ -65,15 +87,17 @@ Usage:
     })
     .option('f', {
         alias: 'file',
+        type: 'string',
         describe: 'Read query File (pass - to read from standard input)'
     })
     .option('b', {
         alias: 'bind',
+        type: 'string',
         describe: 'Bind variables (either as JSON string or - to read from standard input)', 
         coerce: parseVars, 
         default: () => {}
     })
-    .option('h', {alias: 'help'})
+    .option('h', {alias: 'help', type: 'boolean'})
     .nargs({'f': 1,'b': 1})
     .strict(false)
     .exitProcess(false);

--- a/spec/examples/exist-exec
+++ b/spec/examples/exist-exec
@@ -7,6 +7,51 @@ const {readFileSync} = require("fs")
 // read connection options from ENV
 const connectionOptions = require('../connection')
 
+function parseVars (raw) {
+    let stringified = raw
+    if (raw === '-') {
+        stringified = readFileSync(process.stdin.fd)
+    }
+    if (stringified) {
+        return JSON.parse(stringified)
+    }
+    return {}
+}
+
+function getQuery (file, query) {
+    const hasQueryFile = file && file !== ''
+    const hasQueryString = query && query !== ''
+    
+    if (!hasQueryFile && !hasQueryString) {
+        console.error('No query given, nothing to do!')
+        return 1
+    }
+
+    if (hasQueryFile && hasQueryString) {
+        console.error('Cannot use both query string and query file')
+        return 1
+    }
+
+    // read query from standard input
+    if (query === '-') {
+        return readFileSync(process.stdin.fd, 'utf-8')
+    }
+
+    if (hasQueryString) {
+        return query
+    }
+
+    // read query file content
+    let path = file
+
+    // from standard input
+    if (file === '-') {
+        path = readFileSync(process.stdin.fd, 'utf-8').trim()
+    }
+
+    return readFileSync(path, 'utf-8')
+}
+
 async function execute(db, query, variables) {
     const result = await db.queries.readAll(query, { variables })
     console.log(result.pages.toString())
@@ -18,13 +63,13 @@ async function run() {
     .command('$0', 'Execute queries in an exist-db', (yargs) => {
       yargs.demandCommand(0, 1).usage(`Execute queries in an exist-db
   
-  Usage:
+Usage
     exist-exec [options] [query]`);
     })
-    .option('f', {alias: 'file', describe: 'Read query File', type: 'string', default: '', group: 'Options'})
-    .option('b', {alias: 'bound-variables', describe: 'bound variables as JSON', type: 'string', coerce: JSON.parse, default: {}, group: 'Options'})
+    .option('f', {alias: 'file', describe: 'Read query File (pass - to read from standard input)', group: 'Options'})
+    .option('b', {alias: 'bind', describe: 'Bind variables (either as JSON string or - to read from standard input)', coerce: parseVars, default: () => {}, group: 'Options'})
     .option('h', {alias: 'help', group: 'Options'})
-    .option('v', {alias: 'version', group: 'Options'})
+    .nargs({'f': 1,'b': 1})
     .strict(false)
     .exitProcess(false);
   
@@ -33,27 +78,12 @@ async function run() {
       if (Boolean(parsed.help) || Boolean(parsed.version)) {
         return 0
       }
-      const {file, boundVariables} = parsed
-      const query = parsed._[0]
+      const {file, bind} = parsed
 
-      if (file === '' && !query) {
-        console.error('nothing to do')
-        return 1
-      }
-
-      if (file !== '' && query && query !== '') {
-        console.error('Cannot use both query string and query file')
-        return 1
-      }
-
+      const query = getQuery(file, parsed._[0])
       const db = connect(connectionOptions)
 
-      if (file !== '') {
-        const xqf = readFileSync(file)
-        return await execute(db, xqf, boundVariables)
-      }
-
-      return await execute(db, query, boundVariables)
+      return await execute(db, query, bind)
     }
     catch (error) {
         if (

--- a/spec/examples/exist-exec
+++ b/spec/examples/exist-exec
@@ -23,13 +23,11 @@ function getQuery (file, query) {
     const hasQueryString = query && query !== ''
     
     if (!hasQueryFile && !hasQueryString) {
-        console.error('No query given, nothing to do!')
-        return 1
+        throw Error('No query given, nothing to do!')
     }
 
     if (hasQueryFile && hasQueryString) {
-        console.error('Cannot use both query string and query file')
-        return 1
+        throw Error('Cannot use both query string and query file')
     }
 
     // read query from standard input
@@ -61,14 +59,21 @@ async function execute(db, query, variables) {
 async function run() {
     const cli = require('yargs')
     .command('$0', 'Execute queries in an exist-db', (yargs) => {
-      yargs.demandCommand(0, 1).usage(`Execute queries in an exist-db
-  
-Usage
+      yargs.demandCommand(0, 1).usage(`
+Usage:
     exist-exec [options] [query]`);
     })
-    .option('f', {alias: 'file', describe: 'Read query File (pass - to read from standard input)', group: 'Options'})
-    .option('b', {alias: 'bind', describe: 'Bind variables (either as JSON string or - to read from standard input)', coerce: parseVars, default: () => {}, group: 'Options'})
-    .option('h', {alias: 'help', group: 'Options'})
+    .option('f', {
+        alias: 'file',
+        describe: 'Read query File (pass - to read from standard input)'
+    })
+    .option('b', {
+        alias: 'bind',
+        describe: 'Bind variables (either as JSON string or - to read from standard input)', 
+        coerce: parseVars, 
+        default: () => {}
+    })
+    .option('h', {alias: 'help'})
     .nargs({'f': 1,'b': 1})
     .strict(false)
     .exitProcess(false);

--- a/spec/examples/exist-exec
+++ b/spec/examples/exist-exec
@@ -2,7 +2,7 @@
 
 const {argv} = require('process'); // eslint-disable-line node/prefer-global/process
 const {connect} = require('../../index')
-const {readFileSync, fstat} = require("fs")
+const {readFileSync} = require("fs")
 
 // read connection options from ENV
 const connectionOptions = require('../connection')

--- a/spec/examples/exist-install
+++ b/spec/examples/exist-install
@@ -69,19 +69,17 @@ async function install (db, localFilePath) {
 async function run() {
   const cli = require("yargs")
     .command("$0", "Install XAR package", (yargs) => {
-      yargs.demandCommand(1, 1).usage(`Install XAR package
-  
-  Usage:
+      yargs.demandCommand(1, 1).usage(`
+Usage:
     exist-install package`);
     })
-    .option("h", { alias: "help", group: "Options" })
-    .option("v", { alias: "version", group: "Options" })
+    .option("h", { alias: "help"})
     .strict(false)
     .exitProcess(false);
 
   try {
     const parsed = cli.parse(argv.slice(2));
-    if (Boolean(parsed.help) || Boolean(parsed.version)) {
+    if (Boolean(parsed.help)) {
       return 0;
     }
 

--- a/spec/examples/exist-ls
+++ b/spec/examples/exist-ls
@@ -144,8 +144,7 @@ async function ls(collection, options) {
 async function run() {
   const cli = require("yargs")
     .command("$0", "List connection contents", (yargs) => {
-      yargs.demandCommand(1, 1).usage(`List connection contents
-  
+      yargs.demandCommand(1, 1).usage(`
   Usage:
     exist-ls [options] collection`);
     })
@@ -154,14 +153,12 @@ async function run() {
       describe: "Color the output",
       default: false,
       type: "boolean",
-      group: "Options",
     })
     .option("l", {
       alias: "extended",
       describe: "Display more information for each item",
       default: false,
       type: "boolean",
-      group: "Options",
     })
     .option("g", {
       alias: "glob",
@@ -169,16 +166,14 @@ async function run() {
         "Include only collection names and resources whose name match the pattern.",
       type: String,
       default: "*",
-      group: "Options",
     })
-    .option("h", { alias: "help", group: "Options" })
-    .option("v", { alias: "version", group: "Options" })
+    .option("h", { alias: "help"})
     .strict(false)
     .exitProcess(false);
 
   try {
     const parsed = cli.parse(argv.slice(2));
-    if (Boolean(parsed.help) || Boolean(parsed.version)) {
+    if (Boolean(parsed.help)) {
       return 0;
     }
 

--- a/spec/examples/exist-tree
+++ b/spec/examples/exist-tree
@@ -115,22 +115,24 @@ async function tree (collection, level) {
 
 async function run() {
     const cli = require('yargs')
-    .command('$0', 'Upload resources into an exist-db', (yargs) => {
-      yargs.demandCommand(1, 1).usage(`List a collection and its contents as a tree
-  
-  Usage:
+    .command('$0', 'List a collection and its contents as a tree', (yargs) => {
+      yargs.demandCommand(1, 1).usage(`  
+Usage:
     exist-tree [options] collection`);
     })
-    // .option('d', {alias: 'dry-run', describe: 'Show what would be uploaded', type: 'boolean', group: 'Options'})
-    .option('l', {alias: 'level', describe: 'The maximum depth of the tree. Setting this to zero will output the complete tree.', type: Number, default: 0, group: 'Options'})
-    .option('h', {alias: 'help', group: 'Options'})
-    .option('v', {alias: 'version', group: 'Options'})
+    .option('l', {
+        alias: 'level',
+        describe: 'The maximum depth of the tree. Setting this to zero will output the complete tree.', 
+        type: Number,
+        default: 0
+    })
+    .option('h', {alias: 'help'})
     .strict(false)
     .exitProcess(false);
   
     try {
       const parsed = cli.parse(argv.slice(2))
-      if (Boolean(parsed.help) || Boolean(parsed.version)) {
+      if (Boolean(parsed.help)) {
         return 0
       }
       const {level} = parsed

--- a/spec/examples/exist-upload
+++ b/spec/examples/exist-upload
@@ -209,9 +209,8 @@ async function uploadFileOrFolder(db, source, target, options) {
 
 async function run() {
   const cli = require('yargs')
-  .command('$0', 'Upload resources into an exist-db', (yargs) => {
-    yargs.demandCommand(2, 2).usage(`Upload files and directories to a target collection in exist-db
-
+  .command('$0', 'Upload files and directories to a target collection in exist-db', (yargs) => {
+    yargs.demandCommand(2, 2).usage(`
 Usage:
   exist-up [options] source target`);
   })
@@ -219,30 +218,51 @@ Usage:
     alias: 'include', 
     describe: 'Include only files matching one or more of include patterns (comma separated)',
     default: "**",
-    ...stringList, 
-    group: 'Options'
+    ...stringList
   })
   .option('e', {
     alias: 'exclude', 
     describe: 'Exclude any file matching one or more of exclude patterns (comma separated)',
     default: [],
-    ...stringList, 
-    group: 'Options'
+    ...stringList
   })
-  .option('v', {alias: 'verbose', describe: 'Log every file and resource that was created', type: 'boolean', default: false, group: 'Options'})
-  .option('d', {alias: 'dry-run', describe: 'Show what would be uploaded', type: 'boolean', group: 'Options'})
-  .option('t', {alias: 'threads', describe: 'The maximum number of concurrent threads that will be used to upload data', type: 'number', default: 4, group: 'Options'})
-  .option('m', {alias: 'mintime', describe: 'The minimum time each upload will take', type: 'number', default: 0, group: 'Options'})
-  .option('a', {alias: 'apply-xconf', describe: 'If set, will upload and apply index configurations that are in the fileset first before all other data is uploaded. The user must be a member of the dba group.', default: false, type: 'boolean', group: 'Options'})
-  .option('h', {alias: 'help', group: 'Options'})
-  // .option('v', {alias: 'version', group: 'Options'})
+  .option('v', {
+    alias: 'verbose',
+    describe: 'Log every file and resource that was created',
+    type: 'boolean',
+    default: false
+  })
+  .option('d', {
+    alias: 'dry-run',
+    describe: 'Show what would be uploaded',
+    type: 'boolean'
+  })
+  .option('t', {
+    alias: 'threads',
+    describe: 'The maximum number of concurrent threads that will be used to upload data',
+    type: 'number',
+    default: 4
+  })
+  .option('m', {
+    alias: 'mintime',
+    describe: 'The minimum time each upload will take',
+    type: 'number',
+    default: 0
+  })
+  .option('a', {
+    alias: 'apply-xconf',
+    describe: 'If set, will upload and apply index configurations that are in the fileset first before all other data is uploaded. The user must be a member of the dba group.',
+    default: false,
+    type: 'boolean'
+  })
+  .option('h', {alias: 'help'})
   .nargs({'i': 1, 'e': 1})
   .strict(false)
   .exitProcess(false);
 
   try {
     const parsed = cli.parse(argv.slice(2))
-    if (Boolean(parsed.help) || Boolean(parsed.version)) {
+    if (Boolean(parsed.help)) {
       return 0
     }
     const {verbose, dryRun, include, exclude, threads, mintime} = parsed

--- a/spec/examples/exist-upload
+++ b/spec/examples/exist-upload
@@ -265,14 +265,12 @@ Usage:
     if (Boolean(parsed.help)) {
       return 0
     }
-    const {verbose, dryRun, include, exclude, threads, mintime} = parsed
+    const {threads, mintime} = parsed
     if (typeof mintime !== 'number' || mintime < 0) {
-      console.error('Invalid value for option "mintime"; must be an integer equal or greater than zero.')
-      return 1
+      throw Error('Invalid value for option "mintime"; must be an integer equal or greater than zero.')
     }
     if (typeof threads !== 'number' || threads <= 0) {
-      console.error('Invalid value for option "threads"; must be an integer equal or greater than zero.')
-      return 1
+      throw Error('Invalid value for option "threads"; must be an integer equal or greater than zero.')
     }
 
     const [source, target] = parsed._
@@ -286,7 +284,7 @@ Usage:
     accountInfo = await getUserInfo(db)
     const isAdmin = accountInfo.groups.includes('dba')
     if (parsed.applyXconf && !isAdmin) {
-      throw Error("To apply configurations you must be member of the dba group.")
+      throw Error("To apply collection configurations you must be member of the dba group.")
     }
 
     const existsAndCanOpenCollection = await db.collections.existsAndCanOpen(target)

--- a/spec/examples/readme.md
+++ b/spec/examples/readme.md
@@ -12,7 +12,7 @@ to be enabled.
 ## connecting to your eXist-db instance
 
 The command line scripts allow you to connect to any instance that has XML-RPC
-enabaled. By default they will attempt to connect to a local development server
+enabled. By default they will attempt to connect to a local development server
 with default passwords.
 
 Override any of the default connection parameters by setting environment 

--- a/spec/examples/readme.md
+++ b/spec/examples/readme.md
@@ -1,13 +1,23 @@
 # node-exist Command Line Scripts
 
-- `exist-ls` list the contents of a collection in exist-db
-- `exist-tree` list the contents of a collection in exist-db as a tree
-- `exist-upload` upload a files and folders to a collection in exist-db
-- `exist-install` upload and install a package into an existdb-instance
-- `exist-exec` execute queries in an existdb-instance
+- `exist-ls` list the contents of a collection in eXist-db
+- `exist-tree` list the contents of a collection in eXist-db as a tree
+- `exist-upload` upload a files and folders to a collection in eXist-db
+- `exist-install` upload and install a package into eXist-db
+- `exist-exec` execute queries in an eXist-db
 
-The three command line script examples allow you to override the connection
-by setting environment variables prefixed with `EXISTDB`.
+**NOTE:** These scripts connect to a running eXist-db instance and XML-RPC has
+to be enabled.
+
+## connecting to your eXist-db instance
+
+The command line scripts allow you to connect to any instance that has XML-RPC
+enabaled. By default they will attempt to connect to a local development server
+with default passwords.
+
+Override any of the default connection parameters by setting environment 
+variables prefixed with `EXISTDB`. In the following table you see a list of the 
+parameters with their default values and a description.
 
 | variable name | default | description
 |----|----|----

--- a/spec/examples/readme.md
+++ b/spec/examples/readme.md
@@ -4,6 +4,7 @@
 - `exist-tree` list the contents of a collection in exist-db as a tree
 - `exist-upload` upload a files and folders to a collection in exist-db
 - `exist-install` upload and install a package into an existdb-instance
+- `exist-exec` execute queries in an existdb-instance
 
 The three command line script examples allow you to override the connection
 by setting environment variables prefixed with `EXISTDB`.


### PR DESCRIPTION
Supports reading queries from the command line or from a file (with `-f`).
Variables can be bound using the `-b` parameter.

The the path to the query file, the bound variables and even the query string can be read from standard input by using `-`. 

closes #206

## Usage

```
exist-exec

Execute queries in an exist-db

Usage:
exist-exec [options] [query]

Options:
      --version  Show version number                                   [boolean]
  -f, --file     Read query File (pass - to read from standard input)
  -b, --bind     Bind variables (either as JSON string or - to read from
                 standard input)                            [default: (default)]
  -h, --help     Show help                                             [boolean]

```

## Examples

### With query string

```bash
spec/examples/exist-exec '1 to 9'
```
**Output**

```bash
1,2,3,4,5,6,7,8,9

```

### With bound variables

```bash
spec/examples/exist-exec \
  -b '{"from": 1, "to": 50}' \
  'sum($from to $to)'
```

**Output**

```bash
1275
```

### Reading from file and piping output to `jq`

```bash
spec/examples/exist-exec \
  -f xquery/list-resources.xq \
  -b '{"collection":"/db", "glob":"*", "extended":false}' | jq -M
```

**Output**

```bash
[
  {
    "type": "collection",
    "name": "system",
  },
  {
    "type": "collection",
    "name": "apps",
  }
]
```

### Reading bound variables from standard input

```bash
echo '{"a":16}' | spec/examples/exist-exec -b - '$a * $a'
```

**Output**

```
256
```

### Reading query string from standard input

```bash
echo '$a * $a' | spec/examples/exist-exec -b '{"a":16}' - 
```

**Output**

```
256
```
