### PR TITLE
feat: run tests against an instance without bundled packages 

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -20,6 +20,10 @@ jobs:
         image: existdb/existdb:${{ matrix.exist-version }}
         ports:
           - 8443:8443
+        volumes:
+          - ${{ github.workspace }}/xquery:/exist/autodeploy
+        options: >-
+          --health-interval 4s
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/components/app.js
+++ b/components/app.js
@@ -13,22 +13,31 @@ const fs = require('fs')
 const path = require('path')
 const queries = require('./queries')
 const documents = require('./documents')
+const collections = require('./collections')
 const xqueryPath = path.resolve(__dirname, '../xquery/')
 const installQueryString = fs.readFileSync(path.join(xqueryPath, 'install-package.xq'))
 const removeQueryString = fs.readFileSync(path.join(xqueryPath, 'remove-package.xq'))
 const defaultPackageRepo = 'https://exist-db.org/exist/apps/public-repo'
+const packageCollection = '/db/pkgtmp'
 
 /**
  * Upload XAR package to an existdb instance
  *
  * @param {XMLRPCClient} client db connection
  * @param {Buffer} xarBuffer XAR package contents (binary zip)
- * @param {String} xarName the filename that will be stored in /db/system/repo
+ * @param {String} xarName the filename that will be stored in ${app.packageCollection}
  * @returns {NormalizedQueryResult} the result of the action
  */
 function upload (client, xarBuffer, xarName) {
-  return documents.upload(client, xarBuffer)
-    .then(fh => documents.parseLocal(client, fh, `/db/system/repo/${xarName}`, {}))
+  return collections.existsAndCanOpen(client, packageCollection)
+    .then(exists => {
+      if (exists) {
+        return Promise.resolve()
+      }
+      return collections.create(client, packageCollection)
+    })
+    .then(_ => documents.upload(client, xarBuffer))
+    .then(fh => documents.parseLocal(client, fh, `${packageCollection}/${xarName}`, {}))
     .then(success => { return { success } })
     .catch(error => { return { success: false, error } })
 }
@@ -38,14 +47,13 @@ function upload (client, xarBuffer, xarName) {
  * A previously installed version will be removed
  *
  * @param {XMLRPCClient} client db connection
- * @param {String} xarName the name of a XAR file, must be present in /db/system/repo
- * @param {String} packageUri unique package descriptor
+ * @param {String} xarName the name of a XAR file, must be present in ${packageCollection}
  * @param {String} [customPackageRepoUrl] a different repository to resolve package dependencies
  * @returns {NormalizedQueryResult} the result of the action
  */
 function install (client, xarName, customPackageRepoUrl) {
   const publicRepoURL = customPackageRepoUrl || defaultPackageRepo
-  const queryOptions = { variables: { xarPath: `/db/system/repo/${xarName}`, publicRepoURL } }
+  const queryOptions = { variables: { xarPath: `${packageCollection}/${xarName}`, publicRepoURL } }
 
   return queries.readAll(client, installQueryString, queryOptions)
     .then(result => JSON.parse(result.pages.toString()))
@@ -97,5 +105,6 @@ module.exports = {
   install,
   upload,
   remove,
-  deploy
+  deploy,
+  packageCollection
 }

--- a/readme.md
+++ b/readme.md
@@ -393,6 +393,18 @@ db.app.remove('http://exist-db.org/apps/test-app')
 }
 ```
 
+#### packageCollection
+
+The path to the collection where node-exist will upload
+packages to (`/db/pkgtmp`). Useful for cleanup after
+succesful installation.
+
+**Example:**
+
+```js
+db.documents.remove(`${db.app.packageCollection}/test-app.xar`)
+```
+
 ### Indices
 
 Status: TODO

--- a/spec/tests/app.js
+++ b/spec/tests/app.js
@@ -71,7 +71,7 @@ test('upload and install application XAR', function (t) {
     st.plan(2)
     db.app.remove(packageUri)
       .then(response => st.equal(response.success, true, 'uninstalled'))
-      .then(_ => db.documents.remove('/db/system/repo/test-app.xar'))
+      .then(_ => db.documents.remove(`${app.packageCollection}/test-app.xar`))
       .then(response => st.equal(response, true, 'removed'))
       .catch(e => st.fail(e))
   })
@@ -95,7 +95,7 @@ test('empty application XAR', function (t) {
       .then(response => {
         st.plan(2)
         st.equal(response.success, false)
-        st.equal(response.error.message, 'experr:EXPATH00 Missing descriptor from package: /db/system/repo/test-empty-app.xar')
+        st.equal(response.error.message, `experr:EXPATH00 Missing descriptor from package: ${app.packageCollection}/test-empty-app.xar`)
       })
       .catch(e => {
         st.fail(e)
@@ -105,7 +105,7 @@ test('empty application XAR', function (t) {
 
   t.test('cleanup', function (st) {
     st.plan(1)
-    db.documents.remove('/db/system/repo/test-empty-app.xar')
+    db.documents.remove(`${app.packageCollection}/test-empty-app.xar`)
       .then(response => st.equal(response, true))
       .catch(e => st.fail(e))
   })

--- a/spec/tests/collections.js
+++ b/spec/tests/collections.js
@@ -83,9 +83,9 @@ test('collection exists and guest cannot open it', function (t) {
 
 test('collection exists and guest can open it', function (t) {
   const db = connect(asGuest)
-  db.collections.existsAndCanOpen('/db/apps/dashboard')
+  db.collections.existsAndCanOpen('/db/apps')
     .then(function (success) {
-      t.true(success, '/db/apps/dashboard exists and user guest can access it')
+      t.true(success, '/db/apps exists and user guest can access it')
       t.end()
     })
     .catch(function (e) {

--- a/spec/tests/users.js
+++ b/spec/tests/users.js
@@ -10,18 +10,19 @@ test('list users', function (t) {
   const db = connect(connectionOptions)
   db.users.list()
     .then(function (list) {
-      t.plan(6)
+      t.plan(4)
       t.ok(list.length, 'Returns a non-empty list of users')
 
       const names = list.map(u => u.name)
       t.true(names.includes('SYSTEM'), 'found user SYSTEM')
       t.true(names.includes('admin'), 'found user admin')
       t.true(names.includes('guest'), 'found user guest')
-      t.true(names.includes('monex'), 'found user monex')
-      t.true(names.includes('eXide'), 'found user eXide')
-      // exist 4.7.1 does not have these users
-      // t.true(names.includes('nobody'), 'found user nobody')
+      // when testing on a package-less installation these users will not be created
+      // t.true(names.includes('monex'), 'found user monex')
+      // t.true(names.includes('eXide'), 'found user eXide')
       // t.true(names.includes('packageservice'), 'found user packageservice')
+      // exist 4.7.1 does not have this user
+      // t.true(names.includes('nobody'), 'found user nobody')
       t.end()
     })
     .catch(function (e) {


### PR DESCRIPTION
Mount autodeploy folder in the docker image to something that does not include a single XAR (here, I used the xquery folder).

This together with some tweaks to the health check speeds up the CI runs to just about a minute from 1:45 
That is almost half the time.

Many thanks to @duncdrum and his knowledge of docker and GHA, for pointing me in the right direction.

Some interesting findings: 
- the collection `/db/system/repo` is not present when not a single package was installed.
  To adapt to that `db.app` now checks for a temporary collection `/db/pkgtmp` and creates it if it does not exist.
  Is the current user not allowed to open that collection (as guest might not be able to) the installation fails.
  But it would fail in any case later on as guest is not allowed to install packages.
- the collection where node-exist will upload its packages is also now exported as `app.packageCollection` to allow
  easy cleanup once installation was successful