### PR TITLE
fix: import in module (esm)

### DIFF
--- a/components/queries.js
+++ b/components/queries.js
@@ -69,9 +69,9 @@ function readAll (client, queryStringOrBuffer, options) {
     .then(function (pages) {
       results = {
         query: queryStringOrBuffer,
-        options: options,
+        options,
         hits: resultPages,
-        pages: pages
+        pages
       }
 
       return releaseResult(client, resultHandle)

--- a/index.js
+++ b/index.js
@@ -51,15 +51,15 @@ function applyEachWith (module, client) {
 }
 
 /**
- * Receive set of bound components to interact with an exist-db instance
- * @param {NodeExistConnectionOptions} options set who connects to which server and how
- * @returns {NodeExist} bound components to interact with an exist-db instance
- */
+  * Receive set of bound components to interact with an exist-db instance
+  * @param {NodeExistConnectionOptions} options set who connects to which server and how
+  * @returns {NodeExist} bound components to interact with an exist-db instance
+  */
 function connect (options) {
   const client = connection.connect(options)
 
   return {
-    client: client,
+    client,
     server: applyEachWith(database, client),
     queries: applyEachWith(queries, client),
     resources: applyEachWith(resources, client),
@@ -71,13 +71,12 @@ function connect (options) {
   }
 }
 
-module.exports = {
-  readOptionsFromEnv: connection.readOptionsFromEnv,
-  connect,
-  defineMimeTypes: function (mimeTypes) {
-    mime.define(mimeTypes)
-  },
-  getMimeType: function (path) {
-    return mime.getType(path)
-  }
+exports.readOptionsFromEnv = connection.readOptionsFromEnv
+exports.connect = connect
+exports.defineMimeTypes = function (mimeTypes) {
+  mime.define(mimeTypes)
+}
+
+exports.getMimeType = function (path) {
+  return mime.getType(path)
 }

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ npm install @existdb/node-exist
 Creating, reading and removing a collection:
 
 ```js
-const exist = require('@existdb/node-exist')
-const db = exist.connect()
+const {connect} = require('@existdb/node-exist')
+const db = connect()
 
 db.collections.create('/db/apps/test')
   .then(result => db.collections.describe('/db/apps/test'))
@@ -37,8 +37,8 @@ db.collections.create('/db/apps/test')
 Uploading an XML file into the database
 
 ```js
-const exist = require('@existdb/node-exist')
-const db = exist.connect()
+const {connect} = require('@existdb/node-exist')
+const db = connect()
 
 db.documents.upload(Buffer.from('<root/>'))
   .then(fileHandle => db.documents.parseLocal(fileHandle, '/db/apps/test/file.xml', {}))
@@ -50,8 +50,8 @@ db.documents.upload(Buffer.from('<root/>'))
 Since all interactions with the database are promises you can also use async functions
 
 ```js
-const exist = require('@existdb/node-exist')
-const db = exist.connect()
+const {connect} = require('@existdb/node-exist')
+const db = connect()
 
 async function uploadAndParse (filePath, contents) {
   const fileHandle = await db.documents.upload(contents)

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,17 @@ uploadAndParse('/db/apps/test-file.xml', Buffer.from('<root/>'))
   .catch(error => console.error(error))
 ```
 
+You can now also import node-exist into an ES module
+
+```js
+import {connect} from '@existdb/node-exist'
+const db = connect()
+
+// do something with the db connection
+db.collections.describe('/db/apps')
+  .then(result => console.log(result))
+```
+
 You can also have a look at the 
 [examples](spec/examples) for more use-cases.
 


### PR DESCRIPTION
Allows importing node-exist within an ES module

```js
import {connect} from '@existdb/node-exist'
```