### PR TITLE
chore(examples): exclude spec folder from release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 nohup.out
-.github
-spec
+.github/
+spec/

--- a/package.json
+++ b/package.json
@@ -7,13 +7,6 @@
     "semantic-release": "semantic-release",
     "travis-deploy-once": "travis-deploy-once"
   },
-  "bin": {
-    "exist-tree": "spec/examples/exist-tree",
-    "exist-ls": "spec/examples/exist-ls",
-    "exist-upload": "spec/examples/exist-upload",
-    "exist-install": "spec/examples/exist-install",
-    "exist-exec": "spec/examples/exist-exec"
-  },
   "standard": {
     "ignore": [
       "exist-*"

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ Attempts to translate terminologies into node world. Uses promises.
 npm install @existdb/node-exist
 ```
 
+__NOTE:__ If you are looking for a command line client have a look at [xst](https://github.com/line-o/xst)
+
 ## Use
 
 Creating, reading and removing a collection:
@@ -485,30 +487,16 @@ Note: There is no way to bring it up again.
 
 ## Command Line Scripts
 
-You can use this library to interact with local or remote existdb instances on the command line.
-You can find a few basic [examples](spec/examples) in this repository.
+You can use this library to build a command line interface that interacts with existdb instances.
+A few basic [examples](spec/examples) how to do this are included in this repository.
 
-To give you a taste all example scripts are exposed as binaries in the __node_modules/.bin__ folder when you install this package.
-
-You can run them using `npx`
+Example:
 
 ```bash
-npx -p @existdb/node-exist exist-ls /db/apps
+spec/examples/exist-ls /db/apps
 ```
 
-If you want you can even install this package globally and then use these scripts like `ls` or `cd`.
-
-```bash
-npm install -g @existdb/node-exist
-```
-
-Now you can type
-
-```bash
-exist-ls /db/apps
-```
-
-anywhere on the system.
+__NOTE:__ Have a look at [xst](https://github.com/line-o/xst) for a CLI client built with node-exist.
 
 ## Test
 

--- a/spec/examples/readme.md
+++ b/spec/examples/readme.md
@@ -1,4 +1,6 @@
-# node-exist Command Line Scripts
+# node-exist CLI examples
+
+You need to clone this repository to get access to the command line examples.
 
 - `exist-ls` list the contents of a collection in eXist-db
 - `exist-tree` list the contents of a collection in eXist-db as a tree
@@ -50,19 +52,7 @@ prepend command line script with `dotenv` in the folder you created the .env fil
 
 #### Examples
 
-If you installed node-exist globally (`npm install -g @existdb/node-exist`)
-
-```bash
-dotenv exist-ls /db/apps
-```
-
-If you installed node-exist as a local package (npm dependency)
-
-```bash
-dotenv node_modules/.bin/exist-ls /db/apps
-```
-
-If you cloned this repository
+You need to clone this repository, then
 
 ```bash
 dotenv spec/examples/exist-ls /db/apps


### PR DESCRIPTION
BREAKING CHANGE: Installing this package globally does not expose the
command line examples anymore as the entire spec folder is now excluded.
Please have a look at [xst](https://github.com/line-o/xst) for a command
line client to interact with existdb instances.