### PR TITLE
fix: parseLocal without options

### DIFF
--- a/components/documents.js
+++ b/components/documents.js
@@ -6,8 +6,8 @@ function upload (client, contentBuffer) {
 
 function parseLocal (client, handle, filename, options) {
   // set default values
-  const mimeType = getMimeType(filename, options.mimetype)
-  const replace = options.replace || true
+  const mimeType = getMimeType(filename, options && options.mimetype ? options.mimetype : null)
+  const replace = options && options.replace ? options.replace : true
 
   return client.promisedMethodCall('parseLocal', [handle, filename, replace, mimeType])
 }

--- a/spec/tests/resources.js
+++ b/spec/tests/resources.js
@@ -77,7 +77,7 @@ test('resources:', function (t) {
         return db.documents.upload(Buffer.from('1'))
       })
       .then(function (fh) {
-        return db.documents.parseLocal(fh, testCollection + '/test.xql', {})
+        return db.documents.parseLocal(fh, testCollection + '/test.xql')
       })
       .then(function (r) {
         setup.ok(r, 'setup ended')


### PR DESCRIPTION
`parseLocal` will use defaults for `mimetype` and `replace` when called without options.