### PR TITLE
feat: add facility to read binary resources

### DIFF
--- a/components/documents.js
+++ b/components/documents.js
@@ -16,6 +16,10 @@ function read (client, documentName, options) {
   return client.promisedMethodCall('getDocument', [documentName, options])
 }
 
+function readBinary (client, documentName) {
+  return client.promisedMethodCall('getBinaryResource', [documentName])
+}
+
 function remove (client, documentName) {
   return client.promisedMethodCall('remove', [documentName])
 }
@@ -24,5 +28,6 @@ module.exports = {
   upload,
   parseLocal,
   read,
+  readBinary,
   remove
 }

--- a/readme.md
+++ b/readme.md
@@ -296,8 +296,36 @@ db.documents.parseLocal(fileHandle, 'foo/test.txt', {})
 
 #### read
 
+Allows to read XMLResources. You can control how the document is serialized by
+setting 
+[serialization options](https://exist-db.org/exist/apps/doc/xquery.xml?field=all&id=D3.49.19#serialization)
+in the options parameter.
+
+Use default serialization options.
+
 ```js
-db.documents.read('foo.xml')
+db.documents.read('foo.xml', {})
+```
+
+Force XML declaration to be returned.
+
+```js
+db.documents.read('foo.xml', { "omit-xml-declaration": "no" })
+```
+
+Force the file to end in a blank line (available since eXist-db v6.0.1).
+
+```js
+db.documents.read('foo.xml', { "insert-final-newline": "yes" })
+```
+
+#### readBinary
+
+Allows to read XQuery, textfiles, images and other resources existdb treats as
+binary.
+
+```js
+db.documents.readBinary('foo.xml')
 ```
 
 #### remove

--- a/readme.md
+++ b/readme.md
@@ -296,8 +296,8 @@ db.documents.parseLocal(fileHandle, 'foo/test.txt', {})
 
 #### read
 
-Allows to read XMLResources. You can control how the document is serialized by
-setting 
+Reads resources stored as XML (`XMLResource`). You can control how they are
+serialized by setting 
 [serialization options](https://exist-db.org/exist/apps/doc/xquery.xml?field=all&id=D3.49.19#serialization)
 in the options parameter.
 
@@ -321,8 +321,8 @@ db.documents.read('foo.xml', { "insert-final-newline": "yes" })
 
 #### readBinary
 
-Allows to read XQuery, textfiles, images and other resources existdb treats as
-binary.
+Reads resources stored as binary (`BinaryResource`) inside existdb such as XQuery,
+textfiles, PDFs, CSS, images and the like.
 
 ```js
 db.documents.readBinary('foo.xml')

--- a/spec/tests/documents.js
+++ b/spec/tests/documents.js
@@ -3,18 +3,31 @@ const { readFileSync } = require('fs')
 const { connect } = require('../../index')
 const { envOptions } = require('../connection')
 
-test('upload document', function (t) {
+test('binary document', function (t) {
+  const path = '/db/test.txt'
+  const content = Buffer.from('test')
   const db = connect(envOptions)
-  const buffer = Buffer.from('test')
 
-  db.documents.upload(buffer, buffer.length)
-    .then(function (result) {
-      t.ok(result >= 0, 'returned filehandle')
-      t.end()
-    })
-    .catch(function (e) {
+  t.test('should upload', async function (st) {
+    try {
+      const db = connect(envOptions)
+      const fh = await db.documents.upload(content, content.length)
+      st.ok(fh >= 0, 'returned filehandle:' + fh)
+      const r = await db.documents.parseLocal(fh, path)
+      st.ok(r)
+    } catch (e) {
       t.fail(e)
-      t.end()
+    }
+  })
+
+  t.test('can be read', async function (st) {
+    try {
+      const readContent = await db.documents.readBinary(path)
+      console.log(readContent.toString())
+      st.equal(content.toString(), readContent.toString(), 'returned contents equal')
+    } catch (e) {
+      st.fail(e)
+    }
     })
 })
 

--- a/spec/tests/documents.js
+++ b/spec/tests/documents.js
@@ -14,7 +14,7 @@ test('binary document', function (t) {
       const fh = await db.documents.upload(content, content.length)
       st.ok(fh >= 0, 'returned filehandle:' + fh)
       const r = await db.documents.parseLocal(fh, path)
-      st.ok(r)
+      st.ok(r, 'was parsed')
     } catch (e) {
       t.fail(e)
     }
@@ -23,12 +23,11 @@ test('binary document', function (t) {
   t.test('can be read', async function (st) {
     try {
       const readContent = await db.documents.readBinary(path)
-      console.log(readContent.toString())
-      st.equal(content.toString(), readContent.toString(), 'returned contents equal')
+      st.deepEqual(content, readContent, 'returned contents equal')
     } catch (e) {
       st.fail(e)
     }
-    })
+  })
 })
 
 test('upload invalid XML', function (t) {


### PR DESCRIPTION
`db.documents.readBinary(path)` allows to read XQuery, textfiles, images and other resources existdb treats as binary.

needs #266 to be merged first