### PR TITLE
fix(restClient): protocol in connectionOptions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -20,6 +20,7 @@ jobs:
         image: existdb/existdb:${{ matrix.exist-version }}
         ports:
           - 8443:8443
+          - 8080:8080
         volumes:
           - ${{ github.workspace }}/xquery:/exist/autodeploy
         options: >-

--- a/components/connection.js
+++ b/components/connection.js
@@ -32,7 +32,7 @@ const defaultRPCoptions = {
 
 const defaultRestOptions = {
   host: 'localhost',
-  protocol: 'https',
+  protocol: 'https:',
   port: '8443',
   path: '/exist/rest',
   basic_auth: {
@@ -104,7 +104,7 @@ async function restConnection (options) {
 
   const port = _options.port ? ':' + _options.port : ''
   const path = _options.path.startsWith('/') ? _options.path : '/' + _options.path
-  const prefixUrl = `${_options.protocol}://${_options.host}${port}${path}`
+  const prefixUrl = `${_options.protocol}//${_options.host}${port}${path}`
 
   const client = got.extend(
     {

--- a/spec/tests/rest.js
+++ b/spec/tests/rest.js
@@ -382,3 +382,33 @@ return $r
     unlinkSync('stream-test.xml')
   })
 })
+
+test.only('with rest client over http', async function (t) {
+  const modifiedOptions = Object.assign({ protocol: 'http:', port: '8080' }, envOptions)
+  const rc = await getRestClient(modifiedOptions)
+
+  t.test('non-existent file returns 404', async function (st) {
+    try {
+      const res = await rc.get('db/rest-test/non-existent.file')
+      st.fail(res)
+      st.end()
+    } catch (e) {
+      st.equal(e.response.statusCode, 404)
+      st.end()
+    }
+  })
+
+  t.test('getting a collection will return the file listing as xml', async function (st) {
+    try {
+      const res = await rc.get('db')
+      st.equal(res.statusCode, 200, 'server responded with status ' + res.statusCode)
+
+      const lines = res.body.split('\n')
+      st.equal(lines[0], '<exist:result xmlns:exist="http://exist.sourceforge.net/NS/exist">')
+      st.end()
+    } catch (e) {
+      st.fail(e)
+      st.end()
+    }
+  })
+})


### PR DESCRIPTION
The protocol _must_ end with a colon. This lead to the prefixUrl to contain a double colon (`::`), also known as Paamayim Nekudotayim.

For the tests with the protocol set to `http:` the other port (8080) is now exposed in the container in the CI test setup.