### PR TITLE
Improve and adapt tests and npm scripts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,14 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  commit-message:
+    prefix: "chore"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: y18n
-    versions:
-    - 4.0.1
-    - 4.0.2
-  - dependency-name: semantic-release
-    versions:
-    - 17.4.0
-    - 17.4.1
-  - dependency-name: tape
-    versions:
-    - 5.1.1
-    - 5.2.1
-  - dependency-name: mime
-    versions:
-    - 2.5.0
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "04:00"
+  commit-message:
+    prefix: "chore"
+  open-pull-requests-limit: 10

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,17 +8,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        node-version: [14, 16, 18]
-        exist-version: [release, 5.4.1, 4.10.0]
+        node-version: [16, 18, 20]
+        exist-version: [4.10.0, 5.4.1, release]
         experimental: [false]
         include:
           - exist-version: latest
+            node-version: 20
             experimental: true
     services:
       # Label used to access the service container

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -9,11 +9,17 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node-version: [14, 16, 18]
-        exist-version: [latest, release, 5.4.1, 4.10.0]
+        exist-version: [release, 5.4.1, 4.10.0]
+        experimental: [false]
+        include:
+          - exist-version: latest
+            experimental: true
     services:
       # Label used to access the service container
       exist:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -17,8 +17,8 @@ jobs:
         exist-version: [4.10.0, 5.4.1, release]
         experimental: [false]
         include:
-          - exist-version: latest
-            node-version: 20
+          - node-version: 20
+            exist-version: latest
             experimental: true
     services:
       # Label used to access the service container

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "description": "promise based interaction with eXist DB's XML-RPC API",
   "main": "index.js",
   "scripts": {
-    "test": "standard --fix && tape spec/tests/*.js",
-    "semantic-release": "semantic-release",
-    "travis-deploy-once": "travis-deploy-once"
+    "test": "standard && tape spec/tests/*.js --no-only",
+    "lint": "standard --fix",
+    "semantic-release": "semantic-release"
   },
   "standard": {
     "ignore": [

--- a/spec/tests/documents.js
+++ b/spec/tests/documents.js
@@ -50,8 +50,9 @@ test('upload invalid XML', function (t) {
     })
 })
 
-test('valid XML', function (t) {
+test('valid XML', async function (t) {
   const db = connect(envOptions)
+  const version = await db.server.version()
   const remoteFileName = '/test.xml'
   const contents = readFileSync('spec/files/test.xml')
 
@@ -72,8 +73,10 @@ test('valid XML', function (t) {
     try {
       const contentBuffer = await db.documents.read(remoteFileName, {})
       const lines = contents.toString().split('\n')
+
       // default serialization removes first (XML declaration) line
       lines.shift()
+
       // and last line (final newline)
       lines.pop()
       const expectedContents = lines.join('\n')
@@ -88,6 +91,7 @@ test('valid XML', function (t) {
     try {
       const options = { 'omit-xml-declaration': 'yes' }
       const lines = contents.toString().split('\n')
+
       // default serialization removes first (XML declaration) line
       lines.shift()
       // and last line (final newline)
@@ -122,7 +126,6 @@ test('valid XML', function (t) {
     try {
       // skip this test for older versions as
       // insert-final-newline is only available with eXist-db >6.0.1
-      const version = await db.server.version()
       if (!semverGt(version, '6.0.1')) {
         return st.skip('insert-final-newline not implemented in ' + version)
       }
@@ -143,7 +146,6 @@ test('valid XML', function (t) {
   t.test('cleanup', async function (st) {
     try {
       await db.documents.remove(remoteFileName)
-      t.end()
     } catch (e) {
       t.end()
     }

--- a/spec/tests/rest.js
+++ b/spec/tests/rest.js
@@ -383,7 +383,7 @@ return $r
   })
 })
 
-test.only('with rest client over http', async function (t) {
+test('with rest client over http', async function (t) {
   const modifiedOptions = Object.assign({ protocol: 'http:', port: '8080' }, envOptions)
   const rc = await getRestClient(modifiedOptions)
 


### PR DESCRIPTION
`npm test` checks:
   - if coding style is adhered and will error now if any problems occur
   - if a test is marked as `.only` the tests will not run but fail instead

`npm run lint` will check coding style and automatically fix any problem that can be auto-fixed

Mark exist-db v7.0.0-SNAPSHOT (`latest` image) as experimental as it obviously has an issue resulting in two test reproducibly failing.

Change test-matrix to only test on node versions 16, 18, 20 (dropping 14 which has reached EOL).

Add GitHub-actions to dependot configuration.