### PR TITLE
fix(connection): misleading warning message

### DIFF
--- a/components/connection.js
+++ b/components/connection.js
@@ -138,7 +138,7 @@ function mergeOptions (path, options) {
     if (!isSecureClient) {
       console.warn('Connecting to remote DB using an unencrypted channel.')
     }
-    if (!mergedOptions.rejectUnauthorized) {
+    if (('rejectUnauthorized' in mergedOptions) && !mergedOptions.rejectUnauthorized) {
       console.warn('Connecting to remote DB allowing invalid certificate.')
     }
   }

--- a/spec/tests/index.js
+++ b/spec/tests/index.js
@@ -71,6 +71,32 @@ test('create insecure client using legacy option', function (t) {
   t.end()
 })
 
+test('create secure client to remote db', function (t) {
+  const host = 'exist-db.org'
+  const protocol = 'https:'
+  const remoteDb = port => connect({ host, protocol, port })
+  const check = async function (db, st) {
+    st.equal(db.client.isSecure, true, 'secure client used')
+
+    try {
+      const result = await db.resources.describe('/db')
+      st.fail(result, result)
+    } catch (e) {
+      st.equal(e.message, 'XML-RPC fault: Wrong password for user [guest] ', e)
+    }
+
+    st.end()
+  }
+
+  t.test('using standard port', async function (st) {
+    await check(remoteDb('443'), st)
+  })
+
+  t.test('using empty port', async function (st) {
+    await check(remoteDb(''), st)
+  })
+})
+
 test('get collection permissions', function (t) {
   const db = connect(envOptions)
   db.resources.getPermissions('/db')

--- a/spec/tests/rest.js
+++ b/spec/tests/rest.js
@@ -412,3 +412,33 @@ test('with rest client over http', async function (t) {
     }
   })
 })
+
+test('with rest client connecting to exist-db.org as guest with standard port', async function (t) {
+  const rc = await getRestClient({ host: 'exist-db.org', port: 443 })
+
+  t.test('getting a collection listing is rejected as unauthorized', async function (st) {
+    try {
+      const res = await rc.get('db')
+      st.fail(res)
+    } catch (e) {
+      st.equal(e.response.statusCode, 401)
+    }
+    st.end()
+  })
+})
+
+test('with rest client connecting to exist-db.org from URL', async function (t) {
+  const { protocol, hostname, port } = new URL('https://exist-db.org/')
+  // NOTE: that host is mapped to hostname
+  const rc = await getRestClient({ protocol, host: hostname, port })
+
+  t.test('getting a collection listing is rejected as unauthorized', async function (st) {
+    try {
+      const res = await rc.get('db')
+      st.fail(res)
+    } catch (e) {
+      st.equal(e.response.statusCode, 401)
+    }
+    st.end()
+  })
+})


### PR DESCRIPTION
When connecting to a remote DB over an encrypted channel users might be greeted with a warning:
"Connecting to remote DB allowing invalid certificate." This is misleading in cases where `rejectUnauthorized` is not explicitly set.

The added tests will connect to exist-db.org over https. They only check the connection is established and rejected as unauthorized.