### PR TITLE
options default to empty Objects

### DIFF
--- a/components/documents.js
+++ b/components/documents.js
@@ -4,7 +4,7 @@ function upload (client, contentBuffer) {
   return client.promisedMethodCall('upload', [contentBuffer, contentBuffer.length])
 }
 
-function parseLocal (client, handle, filename, options) {
+function parseLocal (client, handle, filename, options = {}) {
   // set default values
   const mimeType = getMimeType(filename, options && options.mimetype ? options.mimetype : null)
   const replace = options && options.replace ? options.replace : true
@@ -12,7 +12,7 @@ function parseLocal (client, handle, filename, options) {
   return client.promisedMethodCall('parseLocal', [handle, filename, replace, mimeType])
 }
 
-function read (client, documentName, options) {
+function read (client, documentName, options = {}) {
   return client.promisedMethodCall('getDocument', [documentName, options])
 }
 

--- a/components/queries.js
+++ b/components/queries.js
@@ -13,7 +13,7 @@ function read (client, query, options = {}) {
   const limit = options.limit || 1
   const start = options.start || 1 // yes, start it seems to be 1-based
 
-  // remmove them from options as they cause NPEs in exist-db XML-RPC 
+  // remmove them from options as they cause NPEs in exist-db XML-RPC
   delete options.limit
   delete options.start
 
@@ -27,7 +27,7 @@ function read (client, query, options = {}) {
  * @param {Object} options
  * @returns {Promise}
  */
-function execute (client, queryStringOrBuffer, options) {
+function execute (client, queryStringOrBuffer, options = {}) {
   return client.promisedMethodCall('executeQuery', [queryStringOrBuffer, options])
 }
 
@@ -51,7 +51,7 @@ function releaseResult (client, handle) {
   return client.promisedMethodCall('releaseQueryResult', [handle])
 }
 
-function readAll (client, queryStringOrBuffer, options) {
+function readAll (client, queryStringOrBuffer, options = {}) {
   let resultHandle = -1
   let resultPages = -1
   let results, error

--- a/components/queries.js
+++ b/components/queries.js
@@ -9,16 +9,15 @@
  * @param {{limit:number, start:number}} [options] - options.limit and options.start control which
  * @returns {Promise}
  */
-function read (client, query, options) {
+function read (client, query, options = {}) {
   const limit = options.limit || 1
-  const start = options.start || 1 // yes, it seems to be 1-based
-  const queryOptions = options || {}
+  const start = options.start || 1 // yes, start it seems to be 1-based
 
-  // these cause null exceptions in exist XML RPC
-  delete queryOptions.start
-  delete queryOptions.limit
+  // remmove them from options as they cause NPEs in exist-db XML-RPC 
+  delete options.limit
+  delete options.start
 
-  return client.promisedMethodCall('query', [query, limit, start, queryOptions])
+  return client.promisedMethodCall('query', [query, limit, start, options])
 }
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ const {connect} = require('@existdb/node-exist')
 const db = connect()
 
 db.documents.upload(Buffer.from('<root/>'))
-  .then(fileHandle => db.documents.parseLocal(fileHandle, '/db/apps/test/file.xml', {}))
+  .then(fileHandle => db.documents.parseLocal(fileHandle, '/db/apps/test/file.xml'))
   .then(result => db.documents.read('/db/apps/test/file.xml'))
   .then(result => console.log('test file contents', result))
   .catch(error => console.error('fail', error))
@@ -353,7 +353,7 @@ db.documents.upload(Buffer.from('test'))
 #### parseLocal
 
 ```js
-db.documents.parseLocal(fileHandle, 'foo/test.txt', {})
+db.documents.parseLocal(fileHandle, 'foo/test.txt')
 ```
 
 #### read
@@ -366,7 +366,7 @@ in the options parameter.
 Use default serialization options.
 
 ```js
-db.documents.read('foo.xml', {})
+db.documents.read('foo.xml')
 ```
 
 Force XML declaration to be returned.

--- a/spec/tests/documents.js
+++ b/spec/tests/documents.js
@@ -60,7 +60,7 @@ test('valid XML', async function (t) {
     try {
       const fh = await db.documents.upload(contents)
       st.ok(fh >= 0, 'returned filehandle')
-      const result = await db.documents.parseLocal(fh, remoteFileName, {})
+      const result = await db.documents.parseLocal(fh, remoteFileName)
       st.ok(result, 'file could be parsed')
       const info = await db.resources.describe(remoteFileName)
       st.ok(info, 'file was written to collection')
@@ -69,9 +69,28 @@ test('valid XML', async function (t) {
     }
   })
 
-  t.test('serialized with default options', async function (st) {
+  t.test('read with empty options uses defaults', async function (st) {
     try {
       const contentBuffer = await db.documents.read(remoteFileName, {})
+      const lines = contents.toString().split('\n')
+
+      // default serialization removes first (XML declaration) line
+      lines.shift()
+
+      // and last line (final newline)
+      lines.pop()
+      const expectedContents = lines.join('\n')
+
+      st.equal(contentBuffer.toString(), expectedContents, 'file was read')
+    } catch (e) {
+      st.fail(e, 'errored')
+    }
+  })
+
+  t.test('read without passing options', async function (st) {
+    try {
+      // calling read with just one argument, effectively passing null for options
+      const contentBuffer = await db.documents.read(remoteFileName)
       const lines = contents.toString().split('\n')
 
       // default serialization removes first (XML declaration) line

--- a/spec/tests/queries.js
+++ b/spec/tests/queries.js
@@ -70,6 +70,25 @@ test('call queryAll method', function (t) {
     })
 })
 
+test('call queryAll method without options', function (t) {
+  const db = connect(envOptions)
+  const queryString = 'for $i in (1,2) return $i + 10'
+  const expectedResult = '11,12'
+
+  db.queries.readAll(queryString)
+    .then(function (result) {
+      const csv = result.pages.map(function (p) { return p.toString() }).join(',')
+      t.equal(result.pages.length, result.hits, 'all pages retrieved')
+      t.equal(csv, expectedResult, 'got expected result')
+      t.deepEqual(result.options, {}, 'options default to empty object')
+      t.end()
+    })
+    .catch(function (e) {
+      t.fail(e)
+      t.end()
+    })
+})
+
 test('run query, expect XML', function (t) {
   t.skip('not implemented yet')
   t.end()


### PR DESCRIPTION
This fixes some hard to understand errors when utilising some node-exist functions:

```
Error: XML-RPC fault: No method matching arguments: java.lang.String, java.lang.String
```