### PR TITLE
feat!: update undici to v8 (Node.js >=22.19), configurable request timeouts

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
         exist-version: [4.10.0, 5.4.1, release]
         experimental: [false]
         include:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "mime": "^4.1.0",
-        "undici": "^7.25.0"
+        "undici": "^8.10.2"
       },
       "devDependencies": {
         "@semantic-release/github": "^12.0.2",
@@ -540,6 +540,16 @@
       },
       "peerDependencies": {
         "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -4959,25 +4969,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "dev": true,
@@ -5539,15 +5530,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
       "dev": true,
@@ -5556,11 +5538,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -5683,14 +5660,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
       }
     },
     "node_modules/npm/node_modules/ini": {
@@ -6423,18 +6392,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -6474,14 +6431,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -6568,24 +6517,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
@@ -6730,51 +6661,11 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
@@ -9002,12 +8893,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "promise based interaction with eXist DB's XML-RPC API",
   "main": "index.js",
   "engines": {
-    "node": "^20.19.0 || >=22.11.0"
+    "node": ">=22.19.0"
   },
   "scripts": {
     "test": "standard && node --test --test-reporter spec spec/tests/*.js",
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "mime": "^4.1.0",
-    "undici": "^7.25.0"
+    "undici": "^8.10.2"
   },
   "version": "0.0.0-development"
 }

--- a/readme.md
+++ b/readme.md
@@ -236,6 +236,19 @@ const db = getXmlRpcClient({
   this is set automatically, because it is impossible to have trusted certificates
   for local hosts.
 
+- Give up on requests that take longer than **ten minutes**
+  ```js
+  {
+    timeout: 600000
+  }
+  ```
+  `timeout` is in milliseconds and applies both to waiting for the response
+  headers and to the pause between two chunks of the response body.
+  The default, `0`, waits indefinitely, so long running queries are not cut
+  off by the client. Queries and REST `post` accept a `timeout` in their
+  options that overrides it for a single call.
+  Package operations (`db.app.*`) never time out.
+
 ### Read options from environment
 
 `readOptionsFromEnv` offers a comfortable way to read the connection options
@@ -246,6 +259,7 @@ from a set of environment variables
 | `EXISTDB_USER` | _none_ | the user used to connect to the database and to execute queries with
 | `EXISTDB_PASS` | _none_ | the password to authenticate the user against the database
 | `EXISTDB_SERVER` | `https://localhost:8443` | the URL of the database instance to connect to (only http and https protocol allowed)
+| `EXISTDB_TIMEOUT` | _none_ (waits indefinitely) | milliseconds before a request times out, `0` waits indefinitely
 
 **NOTE:** In order to connect to an instance as a user other than `guest`
 _both_ `EXISTDB_USER` _and_ `EXISTDB_PASS` have to be set!
@@ -267,6 +281,15 @@ Every method returns a promise.
 ### Queries
 
 Status: working
+
+`execute`, `read` and `readAll` accept a `timeout` in `options`, in
+milliseconds (`0` waits indefinitely). It overrides the connection
+[timeout](#connection-options) for this query only and is not sent to the
+database.
+
+```js
+db.queries.readAll(query, { variables, timeout: 0 })
+```
 
 #### execute
 

--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@ const db = getXmlRpcClient({
   this is set automatically, because it is impossible to have trusted certificates
   for local hosts.
 
-- Give up on requests that take longer than **ten minutes**
+- Give up on requests that take longer than ten minutes
   ```js
   {
     timeout: 600000

--- a/rest/verbs.js
+++ b/rest/verbs.js
@@ -125,16 +125,12 @@ async function post (client, query, rawPath, options) {
   const properties = []
   const { timeout, ...queryOptions } = options ?? {}
 
-  for (const attributeIndex in postAttributeNames) {
-    const attributeName = postAttributeNames[attributeIndex]
-    if (attributeName in queryOptions) {
-      attributes.push(`${attributeName}="${queryOptions[attributeName]}"`)
-      delete queryOptions[attributeName]
+  for (const [name, value] of Object.entries(queryOptions)) {
+    if (postAttributeNames.includes(name)) {
+      attributes.push(`${name}="${value}"`)
+    } else {
+      properties.push(`<property name="${name}" value="${value}"/>`)
     }
-  }
-
-  for (const option in queryOptions) {
-    properties.push(`<property name="${option}" value="${queryOptions[option]}"/>`)
   }
 
   const body = `<query xmlns="http://exist.sourceforge.net/NS/exist"

--- a/rest/verbs.js
+++ b/rest/verbs.js
@@ -1,10 +1,11 @@
 import { types } from 'node:util'
-import { Readable, Writable } from 'node:stream'
+import { Writable } from 'node:stream'
 import { getMimeType } from '../util/mime.js'
 import { requestTimeouts } from '../util/exist-client.js'
 
 /**
  * @typedef { import("undici").Client } Client
+ * @typedef { import("node:stream").Readable } Readable
  */
 
 const isGeneratorFunction = types.isGeneratorFunction
@@ -32,15 +33,6 @@ async function put (client, body, rawPath, mimetype) {
     'content-type': getMimeType(rawPath, mimetype)
   }
 
-  if (body instanceof Readable) {
-    return client.request({
-      method: 'PUT',
-      path,
-      headers,
-      body
-    })
-  }
-
   if (isGeneratorFunction(body)) {
     return client.request({
       method: 'PUT',
@@ -50,13 +42,12 @@ async function put (client, body, rawPath, mimetype) {
     })
   }
 
+  // no content-length header: undici derives it from the body in bytes,
+  // body.length counts the characters of a string
   return client.request({
     method: 'PUT',
     path,
-    headers: {
-      ...headers,
-      'content-length': body.length
-    },
+    headers,
     body
   })
 }
@@ -156,12 +147,12 @@ async function post (client, query, rawPath, options) {
   </properties>
 </query>`
 
+  // no content-length header: undici derives it from the body in bytes
   const response = await client.request({
     method: 'POST',
     path,
     headers: {
-      'content-type': 'application/xml',
-      'content-length': body.length
+      'content-type': 'application/xml'
     },
     body,
     ...requestTimeouts(timeout)

--- a/rest/verbs.js
+++ b/rest/verbs.js
@@ -1,6 +1,7 @@
 import { types } from 'node:util'
 import { Readable, Writable } from 'node:stream'
 import { getMimeType } from '../util/mime.js'
+import { requestTimeouts } from '../util/exist-client.js'
 
 /**
  * @typedef { import("undici").Client } Client
@@ -124,26 +125,25 @@ function extendIfWrapped (response, bodyText) {
  * @param {Client} client REST interface with a database instance
  * @param {string | Buffer } query XQuery main module
  * @param {string} rawPath context path
- * @param {Object} [options] query options
+ * @param {Object} [options] query options, "timeout" overrides the connection timeout and is not sent to the database
  * @returns {Promise<any>} Response with headers and exist specific values
  */
 async function post (client, query, rawPath, options) {
   const path = normalizeDBPath(rawPath)
   const attributes = []
   const properties = []
+  const { timeout, ...queryOptions } = options ?? {}
 
-  if (options) {
-    for (const attributeIndex in postAttributeNames) {
-      const attributeName = postAttributeNames[attributeIndex]
-      if (attributeName in options) {
-        attributes.push(`${attributeName}="${options[attributeName]}"`)
-        delete options[attributeName]
-      }
+  for (const attributeIndex in postAttributeNames) {
+    const attributeName = postAttributeNames[attributeIndex]
+    if (attributeName in queryOptions) {
+      attributes.push(`${attributeName}="${queryOptions[attributeName]}"`)
+      delete queryOptions[attributeName]
     }
+  }
 
-    for (const option in options) {
-      properties.push(`<property name="${option}" value="${options[option]}"/>`)
-    }
+  for (const option in queryOptions) {
+    properties.push(`<property name="${option}" value="${queryOptions[option]}"/>`)
   }
 
   const body = `<query xmlns="http://exist.sourceforge.net/NS/exist"
@@ -163,7 +163,8 @@ async function post (client, query, rawPath, options) {
       'content-type': 'application/xml',
       'content-length': body.length
     },
-    body
+    body,
+    ...requestTimeouts(timeout)
   })
   const bodyText = await response.body.text()
   return Promise.resolve(extendIfWrapped(response, bodyText))

--- a/spec/tests/rest.js
+++ b/spec/tests/rest.js
@@ -344,6 +344,41 @@ return $r
   })
 })
 
+// a string has fewer characters than bytes as soon as it contains non-ASCII characters
+await describe('with rest client and non-ASCII content', async function () {
+  const testCollection = '/db/rest-test-non-ascii'
+  const text = 'äöü € 😀'
+
+  const db = getXmlRpcClient(envOptions)
+  const rc = getRestClient(envOptions)
+
+  await db.collections.create(testCollection)
+
+  await it('create file from non-ASCII string returns Created and reads back unchanged', async function () {
+    const res = await rc.put(text, 'db/rest-test-non-ascii/from-string.txt')
+    assert.strictEqual(res.statusCode, 201)
+    const { bodyText } = await rc.get('db/rest-test-non-ascii/from-string.txt')
+    assert.strictEqual(bodyText, text)
+  })
+
+  await it('create XML file from non-ASCII string returns Created', async function () {
+    const res = await rc.put(`<p>${text}</p>`, 'db/rest-test-non-ascii/from-string.xml')
+    assert.strictEqual(res.statusCode, 201)
+    const { bodyText } = await rc.get('db/rest-test-non-ascii/from-string.xml')
+    assert.match(bodyText, /<p>äöü € 😀<\/p>/)
+  })
+
+  await it('post query with non-ASCII characters', async function () {
+    const res = await rc.post(`"${text}"`, 'db/rest-test-non-ascii')
+    assert.strictEqual(res.statusCode, 200)
+    assert.match(res.bodyText, /äöü € 😀/)
+  })
+
+  await it('teardown', async _ => {
+    await db.collections.remove(testCollection)
+  })
+})
+
 await describe('with rest client over http', async function () {
   const modifiedOptions = Object.assign({ protocol: 'http:', port: '8080' }, envOptions)
   const rc = getRestClient(modifiedOptions)

--- a/spec/tests/timeout.js
+++ b/spec/tests/timeout.js
@@ -1,0 +1,204 @@
+import { test, describe, it } from 'node:test'
+import assert from 'node:assert'
+
+import { getXmlRpcClient, getRestClient, readOptionsFromEnv } from '../../index.js'
+import * as app from '../../xmlrpc/app.js'
+import * as queries from '../../xmlrpc/queries.js'
+import * as verbs from '../../rest/verbs.js'
+import { envOptions } from '../connection.js'
+
+// a timeout set in the environment of the test run must not leak into these tests
+const { timeout, ...connectionOptions } = envOptions
+
+// takes longer than shortTimeout, but keeps the suite fast
+const slowQuery = 'util:wait(1500), "done"'
+const shortTimeout = 500
+
+/**
+ * stands in for an XML-RPC client and records every call
+ * @param {Object} responses canned result per method name
+ * @returns {{calls: Array, methodCall: function}} recording client
+ */
+function recordingClient (responses) {
+  const calls = []
+  const methodCall = async (methodName, params, callOptions) => {
+    calls.push({ methodName, params, callOptions })
+    return responses[methodName]
+  }
+  return { calls, methodCall }
+}
+
+const queryResponses = {
+  executeQuery: 1,
+  getHits: 1,
+  retrieve: Buffer.from('{"success":true,"result":{}}'),
+  releaseQueryResult: true,
+  query: Buffer.from('<exist:result/>')
+}
+
+/**
+ * stands in for an undici client and records every request
+ * @returns {{requests: Array, request: function}} recording client
+ */
+function recordingRestClient () {
+  const requests = []
+  const request = async (options) => {
+    requests.push(options)
+    return { statusCode: 200, headers: {}, body: { text: async () => 'done' } }
+  }
+  return { requests, request }
+}
+
+test('EXISTDB_TIMEOUT', async (t) => {
+  await t.test('is not set when absent or empty', () => {
+    delete process.env.EXISTDB_TIMEOUT
+    assert.ok(!('timeout' in readOptionsFromEnv()))
+    process.env.EXISTDB_TIMEOUT = ''
+    assert.ok(!('timeout' in readOptionsFromEnv()))
+  })
+
+  await t.test('is read in milliseconds', () => {
+    process.env.EXISTDB_TIMEOUT = '600000'
+    assert.strictEqual(readOptionsFromEnv().timeout, 600000)
+  })
+
+  await t.test('accepts 0 to disable the timeout', () => {
+    process.env.EXISTDB_TIMEOUT = '0'
+    assert.strictEqual(readOptionsFromEnv().timeout, 0)
+  })
+
+  await t.test('rejects anything but a non-negative integer', () => {
+    for (const value of ['-1', '1.5', 'ten', '1e3']) {
+      process.env.EXISTDB_TIMEOUT = value
+      assert.throws(() => readOptionsFromEnv(), /EXISTDB_TIMEOUT/, value)
+    }
+  })
+
+  delete process.env.EXISTDB_TIMEOUT
+})
+
+test('connections have no timeout by default', () => {
+  assert.strictEqual(getXmlRpcClient(connectionOptions).connection.timeout, 0)
+  assert.strictEqual(getRestClient(connectionOptions).connection.timeout, 0)
+})
+
+test('connection timeout option is passed on', () => {
+  const options = { ...connectionOptions, timeout: 1000 }
+  assert.strictEqual(getXmlRpcClient(options).connection.timeout, 1000)
+  assert.strictEqual(getRestClient(options).connection.timeout, 1000)
+})
+
+test('per-call timeout', async (t) => {
+  await t.test('queries.execute uses it for the call and does not send it', async () => {
+    const client = recordingClient(queryResponses)
+    await queries.execute(client, '1', { variables: { a: 1 }, timeout: 0 })
+    const [call] = client.calls
+    assert.deepStrictEqual(call.params[1], { variables: { a: 1 } })
+    assert.deepStrictEqual(call.callOptions, { timeout: 0 })
+  })
+
+  await t.test('queries.read uses it for the call and does not send it', async () => {
+    const client = recordingClient(queryResponses)
+    await queries.read(client, '1', { start: 2, limit: 1, timeout: 0 })
+    const [call] = client.calls
+    assert.deepStrictEqual(call.params, ['1', 1, 2, {}])
+    assert.deepStrictEqual(call.callOptions, { timeout: 0 })
+  })
+
+  await t.test('queries.readAll passes it on to every call', async () => {
+    const client = recordingClient(queryResponses)
+    const result = await queries.readAll(client, '1', { timeout: 250 })
+    assert.deepStrictEqual(
+      client.calls.map(call => call.methodName),
+      ['executeQuery', 'getHits', 'retrieve', 'releaseQueryResult']
+    )
+    for (const call of client.calls) {
+      assert.deepStrictEqual(call.callOptions, { timeout: 250 }, call.methodName)
+    }
+    assert.deepStrictEqual(client.calls[0].params[1], {})
+    assert.strictEqual(result.hits, 1)
+  })
+
+  await t.test('queries.readAll without it leaves the connection default', async () => {
+    const client = recordingClient(queryResponses)
+    await queries.readAll(client, '1', { variables: {} })
+    for (const call of client.calls) {
+      assert.strictEqual(call.callOptions?.timeout, undefined, call.methodName)
+    }
+  })
+
+  await t.test('rest post uses it for the request and does not send it', async () => {
+    const client = recordingRestClient()
+    await verbs.post(client, '1', 'db', { start: 1, timeout: 0 })
+    const [request] = client.requests
+    assert.strictEqual(request.headersTimeout, 0)
+    assert.strictEqual(request.bodyTimeout, 0)
+    assert.doesNotMatch(request.body, /timeout/)
+    assert.match(request.body, /start="1"/)
+  })
+
+  await t.test('rest post without it leaves the connection default', async () => {
+    const client = recordingRestClient()
+    await verbs.post(client, '1', 'db')
+    const [request] = client.requests
+    assert.ok(!('headersTimeout' in request))
+    assert.ok(!('bodyTimeout' in request))
+  })
+})
+
+test('package operations never time out', async (t) => {
+  await t.test('app.upload', async () => {
+    const client = recordingClient({ existsAndCanOpenCollection: true, upload: 'handle', parseLocal: true })
+    const result = await app.upload(client, Buffer.from('xar'), 'test.xar')
+    assert.strictEqual(result.success, true)
+    const transfers = client.calls.filter(call => ['upload', 'parseLocal'].includes(call.methodName))
+    assert.strictEqual(transfers.length, 2)
+    for (const call of transfers) {
+      assert.deepStrictEqual(call.callOptions, { timeout: 0 }, call.methodName)
+    }
+  })
+
+  for (const [operation, argument] of [['install', 'test.xar'], ['deploy', 'http://test'], ['remove', 'http://test']]) {
+    await t.test(`app.${operation}`, async () => {
+      const client = recordingClient(queryResponses)
+      const result = await app[operation](client, argument)
+      assert.notStrictEqual(result.success, false, result.error?.message)
+      assert.ok(client.calls.length > 0)
+      for (const call of client.calls) {
+        assert.deepStrictEqual(call.callOptions, { timeout: 0 }, call.methodName)
+      }
+    })
+  }
+})
+
+await describe('XML-RPC timeouts against the database', async () => {
+  const db = getXmlRpcClient({ ...connectionOptions, timeout: shortTimeout })
+
+  await it('aborts a query exceeding the connection timeout', async () => {
+    await assert.rejects(db.queries.readAll(slowQuery), { code: 'UND_ERR_HEADERS_TIMEOUT' })
+  })
+
+  await it('lets the same query finish with a per-call timeout of 0', async () => {
+    const { pages } = await db.queries.readAll(slowQuery, { timeout: 0 })
+    assert.strictEqual(Buffer.concat(pages).toString(), 'done')
+  })
+
+  await it('applies a per-call timeout on a connection without one', async () => {
+    const unlimited = getXmlRpcClient(connectionOptions)
+    await assert.rejects(unlimited.queries.read(slowQuery, { timeout: shortTimeout }), { code: 'UND_ERR_HEADERS_TIMEOUT' })
+  })
+})
+
+await describe('REST timeouts against the database', async () => {
+  const rest = getRestClient({ ...connectionOptions, timeout: shortTimeout })
+
+  await it('aborts a query exceeding the connection timeout', async () => {
+    await assert.rejects(rest.post(slowQuery, 'db'), { code: 'UND_ERR_HEADERS_TIMEOUT' })
+  })
+
+  await it('lets the same query finish with a per-call timeout of 0', async () => {
+    const response = await rest.post(slowQuery, 'db', { timeout: 0 })
+    assert.strictEqual(response.statusCode, 200)
+    assert.match(response.bodyText, /done/)
+  })
+})

--- a/util/connect.js
+++ b/util/connect.js
@@ -21,6 +21,7 @@ import { createExistClient } from './exist-client.js'
  * @prop {string} [port] database port, default: "8443"
  * @prop {string} [path] path to XMLRPC, default: "/exist/xmlrpc"
  * @prop {boolean} [rejectUnauthorized] enforce valid SSL certs, default: true for remote hosts
+ * @prop {number} [timeout] milliseconds to wait for response headers and between body chunks, default: 0 (waits indefinitely)
  */
 
 /**
@@ -123,7 +124,8 @@ function mergeOptions (path, options) {
     headers,
     rejectUnauthorized,
     secure: encrypted,
-    user
+    user,
+    timeout: mergedOptions.timeout
   }
 }
 
@@ -177,6 +179,14 @@ export function readOptionsFromEnv () {
     environmentOptions.protocol = protocol
     environmentOptions.host = hostname
     environmentOptions.port = port
+  }
+
+  if (process.env.EXISTDB_TIMEOUT) {
+    const timeout = process.env.EXISTDB_TIMEOUT
+    if (!/^\d+$/.test(timeout)) {
+      throw new Error('EXISTDB_TIMEOUT must be a number of milliseconds (0 waits indefinitely), got: "' + timeout + '"')
+    }
+    environmentOptions.timeout = parseInt(timeout, 10)
   }
 
   return environmentOptions

--- a/util/exist-client.js
+++ b/util/exist-client.js
@@ -12,6 +12,7 @@ import { Client, interceptors } from 'undici'
  * @prop {boolean} secure indicates if connection is using an encrypted channel (https)
  * @prop {boolean} [rejectUnauthorized=false] enforce valid SSL certs, if https: is used
  * @prop {boolean} [throwOnError=true] controls if the client throws on error
+ * @prop {number} [timeout=0] milliseconds to wait for response headers and between body chunks, 0 waits indefinitely
  */
 
 /**
@@ -21,6 +22,7 @@ import { Client, interceptors } from 'undici'
  * @prop {string} server full URL prefix for requests
  * @prop {string} pathname path prefix that is used for requests
  * @prop {boolean} secure indicates if connection is using an encrypted channel (https)
+ * @prop {number} timeout milliseconds before a request times out, 0 waits indefinitely
  */
 
 const existRequestInterceptor = (basepath, baseheaders) => dispatch => {
@@ -33,17 +35,34 @@ const existRequestInterceptor = (basepath, baseheaders) => dispatch => {
 }
 
 /**
+ * undici request options overriding the connection timeout for a single request
+ * @param {number} [timeout] milliseconds, 0 waits indefinitely, undefined keeps the connection timeout
+ * @returns {{headersTimeout?: number, bodyTimeout?: number}} options to spread into a request
+ */
+export function requestTimeouts (timeout) {
+  if (timeout == null) {
+    return {}
+  }
+  return { headersTimeout: timeout, bodyTimeout: timeout }
+}
+
+/**
  * create a REST client to interact with an exist-db instance
  * @param {ClientOptions} options the connection options
  * @returns {Connection} undici.Client instance
  */
-export function createExistClient ({ server, headers, rejectUnauthorized, user, secure, throwOnError = true }) {
+export function createExistClient ({ server, headers, rejectUnauthorized, user, secure, throwOnError = true, timeout }) {
   const parsed = new URL(server)
   // path prefix has to be passed in to interceptor
   // client cannot work with anything other than clean origin
   const { pathname } = parsed
   parsed.pathname = '/'
+  // undici gives up after 300 seconds by default, queries and package
+  // installations can take much longer
+  const connectionTimeout = timeout ?? 0
   const _client = new Client(parsed, {
+    headersTimeout: connectionTimeout,
+    bodyTimeout: connectionTimeout,
     connect: {
       keepAlive: true,
       rejectUnauthorized
@@ -60,6 +79,7 @@ export function createExistClient ({ server, headers, rejectUnauthorized, user, 
     server,
     user,
     pathname,
+    timeout: connectionTimeout,
     client
   }
 }

--- a/xmlrpc/app.js
+++ b/xmlrpc/app.js
@@ -41,8 +41,9 @@ function upload (client, xarBuffer, xarName) {
       }
       return collections.create(client, packageCollection)
     })
-    .then(_ => documents.upload(client, xarBuffer))
-    .then(fh => documents.parseLocal(client, fh, `${packageCollection}/${xarName}`, {}))
+    // package operations can take long, they must never time out
+    .then(_ => documents.upload(client, xarBuffer, { timeout: 0 }))
+    .then(fh => documents.parseLocal(client, fh, `${packageCollection}/${xarName}`, { timeout: 0 }))
     .then(success => { return { success } })
     .catch(error => { return { success: false, error } })
 }
@@ -58,7 +59,7 @@ function upload (client, xarBuffer, xarName) {
  */
 function install (client, xarName, customPackageRepoUrl) {
   const publicRepoURL = customPackageRepoUrl || defaultPackageRepo
-  const queryOptions = { variables: { xarPath: `${packageCollection}/${xarName}`, publicRepoURL } }
+  const queryOptions = { variables: { xarPath: `${packageCollection}/${xarName}`, publicRepoURL }, timeout: 0 }
 
   return queries.readAll(client, installQueryString, queryOptions)
     .then(result => JSON.parse(result.pages.toString()))
@@ -84,7 +85,7 @@ function install (client, xarName, customPackageRepoUrl) {
  */
 function deploy (client, packageUri) {
   const installQueryString = 'repo:deploy($packageUri)'
-  const queryOptions = { variables: { packageUri } }
+  const queryOptions = { variables: { packageUri }, timeout: 0 }
 
   return queries.readAll(client, installQueryString, queryOptions)
     .then(result => result.pages.toString())
@@ -100,7 +101,7 @@ function deploy (client, packageUri) {
  * @returns {NormalizedQueryResult} the result of the action
  */
 function remove (client, packageUri) {
-  const queryOptions = { variables: { packageUri } }
+  const queryOptions = { variables: { packageUri }, timeout: 0 }
   return queries.readAll(client, removeQueryString, queryOptions)
     .then(result => JSON.parse(result.pages.toString()))
     .catch(error => { return { success: false, error } })

--- a/xmlrpc/app.js
+++ b/xmlrpc/app.js
@@ -42,7 +42,7 @@ function upload (client, xarBuffer, xarName) {
       return collections.create(client, packageCollection)
     })
     // package operations can take long, they must never time out
-    .then(_ => documents.upload(client, xarBuffer, { timeout: 0 }))
+    .then(() => documents.upload(client, xarBuffer, { timeout: 0 }))
     .then(fh => documents.parseLocal(client, fh, `${packageCollection}/${xarName}`, { timeout: 0 }))
     .then(success => { return { success } })
     .catch(error => { return { success: false, error } })

--- a/xmlrpc/documents.js
+++ b/xmlrpc/documents.js
@@ -8,10 +8,11 @@ import { getMimeType } from '../util/mime.js'
  * Upload a document to the database
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {Buffer} contentBuffer the buffer to upload
+ * @param {{timeout: number}} [options] "timeout" overrides the connection timeout
  * @returns {Promise<string>} document handle
  */
-function upload (client, contentBuffer) {
-  return client.methodCall('upload', [contentBuffer, contentBuffer.length])
+function upload (client, contentBuffer, options = {}) {
+  return client.methodCall('upload', [contentBuffer, contentBuffer.length], { timeout: options?.timeout })
 }
 
 /**
@@ -19,7 +20,7 @@ function upload (client, contentBuffer) {
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {string} handle upload handle
  * @param {string} filename local filename
- * @param {{mimetype: string, replace: boolean}} [options] override mimetype and disallow replacing an existing document
+ * @param {{mimetype: string, replace: boolean, timeout: number}} [options] override mimetype, disallow replacing an existing document, override the connection timeout
  * @returns {Promise<string>} document name/path in the database
  */
 function parseLocal (client, handle, filename, options = {}) {
@@ -27,7 +28,7 @@ function parseLocal (client, handle, filename, options = {}) {
   const mimeType = getMimeType(filename, options && options.mimetype ? options.mimetype : null)
   const replace = options && options.replace ? options.replace : true
 
-  return client.methodCall('parseLocal', [handle, filename, replace, mimeType])
+  return client.methodCall('parseLocal', [handle, filename, replace, mimeType], { timeout: options?.timeout })
 }
 
 /**

--- a/xmlrpc/queries.js
+++ b/xmlrpc/queries.js
@@ -3,10 +3,15 @@
  */
 
 /**
+ * @typedef {Object} CallOptions
+ * @prop {number} [timeout] milliseconds before the call times out, 0 waits indefinitely, defaults to the connection timeout
+ */
+
+/**
  * Query the database and receive a (sub)set of results
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {String} query the database query string
- * @param {{limit:number, start:number}} [options] "start" at the n-th result item and "limit" set to n items
+ * @param {{limit:number, start:number, timeout:number}} [options] "start" at the n-th result item and "limit" set to n items, "timeout" overrides the connection timeout
  * @returns {Promise} result set
  */
 function read (client, query, options = {}) {
@@ -17,28 +22,31 @@ function read (client, query, options = {}) {
   delete options.limit
   delete options.start
 
-  return client.methodCall('query', [query, limit, start, options])
+  const { timeout, ...queryOptions } = options
+  return client.methodCall('query', [query, limit, start, queryOptions], { timeout })
 }
 
 /**
  * Execute a query on the database
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {String|Buffer} queryStringOrBuffer the database query can be a string or a buffer (for main modules read from a file)
- * @param {Object} options additional options
+ * @param {Object} options additional options, "timeout" overrides the connection timeout and is not sent to the database
  * @returns {Promise<Number>} result handle
  */
 function execute (client, queryStringOrBuffer, options = {}) {
-  return client.methodCall('executeQuery', [queryStringOrBuffer, options])
+  const { timeout, ...queryOptions } = options ?? {}
+  return client.methodCall('executeQuery', [queryStringOrBuffer, queryOptions], { timeout })
 }
 
 /**
  * count the number of results for a result set identified by result handle
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {Number} handle the result handle
+ * @param {CallOptions} [callOptions] override the connection timeout
  * @returns {Promise<Number>} number of results
  */
-function count (client, handle) {
-  return client.methodCall('getHits', [handle])
+function count (client, handle, callOptions) {
+  return client.methodCall('getHits', [handle], callOptions)
 }
 
 /**
@@ -46,10 +54,11 @@ function count (client, handle) {
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {Number} handle the result handle
  * @param {Number} position the result item to retrieve
+ * @param {CallOptions} [callOptions] override the connection timeout
  * @returns {Promise<any>} the next result item
  */
-function retrieve (client, handle, position) {
-  return client.methodCall('retrieve', [handle, position, {}])
+function retrieve (client, handle, position, callOptions) {
+  return client.methodCall('retrieve', [handle, position, {}], callOptions)
 }
 
 /**
@@ -57,12 +66,13 @@ function retrieve (client, handle, position) {
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {Number} handle the result handle
  * @param {Number} position number of result item to retrieve
+ * @param {CallOptions} [callOptions] override the connection timeout
  * @returns {Promise<Array>} array of all result items
  */
-function retrieveAll (client, handle, position) {
+function retrieveAll (client, handle, position, callOptions) {
   const results = []
   while (position--) {
-    results.push(retrieve(client, handle, position))
+    results.push(retrieve(client, handle, position, callOptions))
   }
   return Promise.all(results.reverse()) // array of results is in reverse order
 }
@@ -71,20 +81,22 @@ function retrieveAll (client, handle, position) {
  * When a result set is no longer needed, release it
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {Number} handle the result handle to release
+ * @param {CallOptions} [callOptions] override the connection timeout
  * @returns {Promise<boolean>} true when the result was released
  */
-function releaseResult (client, handle) {
-  return client.methodCall('releaseQueryResult', [handle])
+function releaseResult (client, handle, callOptions) {
+  return client.methodCall('releaseQueryResult', [handle], callOptions)
 }
 
 /**
  * Convenience function to execute a query and retrieve all results
  * @param {XmlRpcClient} client XML-RPC client instance
  * @param {String|Buffer} queryStringOrBuffer the database query can be a string or a buffer (for main modules read from a file)
- * @param {Object} options additional options
+ * @param {Object} options additional options, "timeout" overrides the connection timeout for every call
  * @returns {Promise<{query: String|Buffer, options: Object, hits: Number, pages: Array}>} all results
  */
 function readAll (client, queryStringOrBuffer, options = {}) {
+  const callOptions = { timeout: options?.timeout }
   let resultHandle = -1
   let resultPages = -1
   let results, error
@@ -92,11 +104,11 @@ function readAll (client, queryStringOrBuffer, options = {}) {
   return execute(client, queryStringOrBuffer, options)
     .then(function (handle) {
       resultHandle = handle
-      return count(client, handle)
+      return count(client, handle, callOptions)
     })
     .then(function (hits) {
       resultPages = hits
-      return retrieveAll(client, resultHandle, hits)
+      return retrieveAll(client, resultHandle, hits, callOptions)
     })
     .then(function (pages) {
       results = {
@@ -106,7 +118,7 @@ function readAll (client, queryStringOrBuffer, options = {}) {
         pages
       }
 
-      return releaseResult(client, resultHandle)
+      return releaseResult(client, resultHandle, callOptions)
     })
     .then(function () {
       return results
@@ -115,7 +127,7 @@ function readAll (client, queryStringOrBuffer, options = {}) {
       error = e
       // try to clean up even after an error if there is something to free
       if (resultHandle >= 0) {
-        return releaseResult(client, resultHandle)
+        return releaseResult(client, resultHandle, callOptions)
       }
       return Promise.reject(e)
     })

--- a/xmlrpc/xmlrpc-client.js
+++ b/xmlrpc/xmlrpc-client.js
@@ -1,4 +1,4 @@
-import { createExistClient } from '../util/exist-client.js'
+import { createExistClient, requestTimeouts } from '../util/exist-client.js'
 
 /**
  * @typedef { import("../util/exist-client.js").Connection } Connection
@@ -7,7 +7,7 @@ import { createExistClient } from '../util/exist-client.js'
 /**
  * @typedef {Object} XmlRpcClient
  * @prop {Connection} connection underlying connection
- * @prop {(methodName: string, params: Array) => Promise} methodCall makes an XML-RPC method call to the connected server
+ * @prop {(methodName: string, params: Array, callOptions?: {timeout?: number}) => Promise} methodCall makes an XML-RPC method call to the connected server
  */
 
 // Map to escape XML special characters
@@ -390,16 +390,23 @@ function parseXmlRpcResponse (xmlResponse) {
  * @param {import('../util/exist-client.js').ConnectionOptions} options connection options
  * @returns {XmlRpcClient} XML-RPC client
  */
-export function createXmlRpcClient ({ server, headers, rejectUnauthorized, user, secure }) {
+export function createXmlRpcClient ({ server, headers, rejectUnauthorized, user, secure, timeout }) {
   const xmlrpcHeaders = {
     Accept: 'text/xml, application/xml',
     'Content-Type': 'text/xml',
     ...headers
   }
 
-  const connection = createExistClient({ server, headers: xmlrpcHeaders, rejectUnauthorized, user, secure, throwOnError: false })
+  const connection = createExistClient({ server, headers: xmlrpcHeaders, rejectUnauthorized, user, secure, timeout, throwOnError: false })
   const { client } = connection
-  const methodCall = async function (methodName, params = []) {
+  /**
+   * Call a remote procedure
+   * @param {string} methodName name of the remote procedure
+   * @param {Array} [params] parameters of the call
+   * @param {{timeout?: number}} [callOptions] "timeout" overrides the connection timeout for this call, 0 waits indefinitely
+   * @returns {Promise<any>} parsed result
+   */
+  const methodCall = async function (methodName, params = [], callOptions) {
     const body = buildXmlRpcCall(methodName, params)
     // TRACE - debug XML-RPC request
     // console.log('XML-RPC Request Body:', body)
@@ -409,7 +416,8 @@ export function createXmlRpcClient ({ server, headers, rejectUnauthorized, user,
       headers: {
         'Content-Length': Buffer.byteLength(body)
       },
-      body
+      body,
+      ...requestTimeouts(callOptions?.timeout)
     }
     const response = await client.request(requestOptions)
     const rpcResponse = await response.body.text()


### PR DESCRIPTION
Closes #398, closes #401. Supersedes #392.

Three commits, meant to be merged as they are (not squashed) so semantic-release sees the breaking change, the feature and the fix.

### 1. `feat!: require Node.js 22.19 and update undici to v8`

- undici `^8.10.2`, engines `>=22.19.0` (not `^22.19.0`, which would exclude Node 24 and 26)
- CI matrix `[22, 24, 26]`, Node 20 dropped
- undici 8 fails on import under Node 20 (`TypeError: webidl.util.markAsUncloneable is not a function`, see the CI of #392), so this is a real breaking change
- undici 8's breaking changes checked against our usage: legacy handler wrappers are gone (our interceptors only pass the handler through), non-real Blob bodies are rejected (not used), `interceptors.responseError` is unchanged
- HTTP/2 is now negotiated by default: eXist 6 answers with HTTP/1.1, eXist 7 selects h2 on its TLS port, and REST and XML-RPC both work over it

### 2. `feat: make request timeouts configurable, wait indefinitely by default`

undici aborts a request after 300 seconds without response headers or without a body chunk, which cut off long running queries and package installations.

- connection option `timeout` in milliseconds, `0` waits indefinitely; the default is now `0`
- `readOptionsFromEnv` reads `EXISTDB_TIMEOUT`
- per call: `timeout` in the options of `queries.execute`, `read`, `readAll` and REST `post` overrides the connection timeout and is not sent to the database; `methodCall(name, params, { timeout })`
- `app.upload`, `install`, `deploy` and `remove` never time out
- documented in the README
- REST `post` no longer deletes attribute options from the object passed in

### 3. `fix(rest): send non-ASCII strings with put and post`

`put` and `post` set `content-length` to `body.length`, which counts characters, not bytes. Any non-ASCII string failed with `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH`, with undici 7 as well. undici derives the header from the body itself, so it is no longer set by hand. Streams were already sent without it.

## Testing

Locally against `existdb/existdb:6.4.0`:

| Node | suite |
|---|---|
| 22.19.0 | 123/123 |
| 24.10.0 | 123/123 |
| 26.8.1 | 123/123 |

New specs: `spec/tests/timeout.js` (24 tests) and a non-ASCII block in `spec/tests/rest.js` (3 tests).

Against `existdb/existdb:latest` (7.0.0-SNAPSHOT, h2): `timeout.js` 24/24 and the non-ASCII REST tests pass. The full suite fails 7 tests there, identically with undici 7 on `main`: eXist 7 behaviour changes (EXPATH007 error message, XML declaration serialized by default, REST `start`/`max`/`cache`), see #339.

The `release` cells in CI have failed on every PR since June (e.g. #391, #394), independent of this change.

## Downstream

xst and gulp-exist depend on `^7.0.0` and keep working until they opt in. Adopting 8.0.0 requires Node.js >=22.19 there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bdrW9vpnvJkeBtS1UZ92E
