### PR TITLE
test: make the suite pass against eXist-db 7

### DIFF
--- a/spec/tests/app.js
+++ b/spec/tests/app.js
@@ -68,7 +68,10 @@ await describe('empty application XAR', async () => {
   await it('install app', async () => {
     const response = await db.app.install(xarName)
     assert.strictEqual(response.success, false)
-    assert.strictEqual(response.error.message, `experr:EXPATH00 Missing descriptor from package: ${app.packageCollection}/test-empty-app.xar`)
+    const { message } = response.error
+    // eXist-db 7 reports EXPATH007 and prefixes the description
+    assert.ok(message.startsWith('experr:EXPATH00'), message)
+    assert.ok(message.endsWith(`Missing descriptor from package: ${app.packageCollection}/test-empty-app.xar`), message)
   })
 
   await it('cleanup', async () => {

--- a/spec/tests/documents.js
+++ b/spec/tests/documents.js
@@ -52,6 +52,12 @@ await describe('valid XML', async function () {
   const remoteFileName = '/test.xml'
   const contents = readFileSync('spec/files/test.xml')
 
+  // eXist-db 7 keeps the XML declaration stored with a document unless the
+  // custom omit-original-xml-declaration is set, omit-xml-declaration alone
+  // does not remove it. Pending https://github.com/eXist-db/exist/pull/6277
+  const storedDeclarationKept = parseInt(version, 10) >= 7 &&
+    'eXist-db 7 keeps the stored XML declaration, see eXist-db/exist#6277'
+
   await it('can be uploaded', async function () {
     try {
       const fh = await db.documents.upload(contents)
@@ -65,7 +71,7 @@ await describe('valid XML', async function () {
     }
   })
 
-  await it('read with empty options uses defaults', async function () {
+  await it('read with empty options uses defaults', { todo: storedDeclarationKept }, async function () {
     try {
       const contentBuffer = await db.documents.read(remoteFileName, {})
       const lines = contents.toString().split('\n')
@@ -83,7 +89,7 @@ await describe('valid XML', async function () {
     }
   })
 
-  await it('read without passing options', async function () {
+  await it('read without passing options', { todo: storedDeclarationKept }, async function () {
     try {
       // calling read with just one argument, effectively passing null for options
       const contentBuffer = await db.documents.read(remoteFileName)
@@ -102,7 +108,7 @@ await describe('valid XML', async function () {
     }
   })
 
-  await it('serialized without XML declaration', async function () {
+  await it('serialized without XML declaration', { todo: storedDeclarationKept }, async function () {
     try {
       const options = { 'omit-xml-declaration': 'yes' }
       const lines = contents.toString().split('\n')

--- a/spec/tests/rest.js
+++ b/spec/tests/rest.js
@@ -273,7 +273,12 @@ return $r
     }
   })
 
-  await it('post honors start and max', async function () {
+  // eXist-db 7.0.0-SNAPSHOT ignores the start and max attributes of a posted query
+  // https://github.com/eXist-db/exist/issues/6560
+  const paginationIgnored = parseInt(await db.server.version(), 10) >= 7 &&
+    'eXist-db 7 ignores start and max, see eXist-db/exist#6560'
+
+  await it('post honors start and max', { todo: paginationIgnored }, async function () {
     try {
       const res = await rc.post(xqueryMainModule, 'db/rest-test', { start: 1, max: 1 })
       assert.strictEqual(res.statusCode, 200, 'server responded with status ' + res.statusCode)
@@ -290,7 +295,7 @@ return $r
     }
   })
 
-  await it('post honors just start', async function () {
+  await it('post honors just start', { todo: paginationIgnored }, async function () {
     try {
       const res = await rc.post(xqueryMainModule, 'db/rest-test', { start: 2 })
       assert.strictEqual(res.statusCode, 200, 'server responded with status ' + res.statusCode)
@@ -306,7 +311,7 @@ return $r
     }
   })
 
-  await it('post honors cache', async function () {
+  await it('post honors cache', { todo: paginationIgnored }, async function () {
     try {
       const res = await rc.post(xqueryMainModule, 'db/rest-test', { cache: 'yes', start: 1, max: 1 })
       assert.strictEqual(res.statusCode, 200, 'server responded with status ' + res.statusCode)


### PR DESCRIPTION
Refs #339

Makes the suite pass against `existdb/existdb:latest` (7.0.0-SNAPSHOT). Seven tests failed there. None of them is a node-exist bug, so this changes tests only, no library code. The `release` cells are deliberately not addressed here (7.0.0-beta4 is about to be released).

## The seven failures

| test(s) | eXist-db 7 behaviour | handling |
|---|---|---|
| `app.js` › empty application XAR › install app | reports `experr:EXPATH007 Generic error from the expath repository library. Package installation failed: Missing descriptor from package: …` instead of `experr:EXPATH00 Missing descriptor from package: …` | assert the `experr:EXPATH00` prefix and the `Missing descriptor from package: …` suffix, which holds for both |
| `rest.js` › post honors start and max / just start / cache | the `start` and `max` attributes of a posted `<exist:query>` are ignored, results always start at 1 and include every hit | `todo` on eXist-db 7, see below |
| `documents.js` › read with empty options uses defaults / read without passing options / serialized without XML declaration | a stored XML declaration is kept, `omit-xml-declaration=yes` does not remove it | `todo` on eXist-db 7, see below |

`todo` tests keep running and are reported, but do not fail the run. Once eXist-db changes the behaviour they show up as passing and the marker can go. The markers are gated on `parseInt(version, 10) >= 7`, so nothing changes for 4.x, 5.x and 6.x.

### REST pagination: eXist-db/exist#6560

A regression in eXist-db 7. The refactor ba806089d (2026-07-07, `RESTServer.doPost: decompose into executePostExecutable, processQueryDocument and processXUpdate`) introduced `parseIntAttribute` with an inverted check:

```java
final String option = root.getAttribute(parameter.xmlKey());
if (option.isEmpty()) {          // should be !option.isEmpty()
    try {
        return Integer.parseInt(option);
```

A present attribute is never parsed, an absent one throws and falls back to the default. Probed against `latest`:

| request | exist:start | exist:count |
|---|---|---|
| POST `<query start="2" max="1">` | 1 | 5 of 5 |
| POST with `?_start=2&_howmany=1` in the URL | 1 | 5 of 5 |
| GET `?_query=…&_start=2&_howmany=1` | 2 | 1 |

`cache="yes"` still works (a session is returned), only the paging is lost. There is no client-side workaround for POST.

### Stored XML declaration: eXist-db/exist#6277

eXist-db 7 added the custom serialization flag `omit-original-xml-declaration`, which takes precedence over the standard `omit-xml-declaration` (introduced with 855922a1). eXist-db/exist#6277 proposes removing it again. Until that is decided the three tests are `todo` on eXist-db 7.

`documents.read` (XML-RPC `getDocument`) of a document stored **with** a declaration:

| options | eXist-db 6.4.1 | eXist-db 7.0.0-SNAPSHOT |
|---|---|---|
| none / `{}` | no declaration | declaration |
| `omit-xml-declaration: yes` | no declaration | declaration |
| `omit-xml-declaration: no` | declaration | declaration |
| `omit-original-xml-declaration: yes` | no declaration | no declaration |
| `omit-xml-declaration: yes` + `omit-original-xml-declaration: yes` | no declaration | no declaration |
| `omit-xml-declaration: no` + `omit-original-xml-declaration: yes` | declaration | declaration |

Documents stored **without** a declaration behave the same on both versions. eXist-db 6.4.1 ignores `omit-original-xml-declaration` entirely.

The flag is not honoured consistently on eXist-db 7 either:

| API, document stored with a declaration | result |
|---|---|
| REST GET with `_omit-xml-declaration=yes` | declaration |
| REST GET with `_omit-original-xml-declaration=yes` | no declaration |
| `queries.readAll('doc(…)')` with either or both flags | declaration |
| `queries.read('doc(…)')` without options | no declaration |

Mirroring the flag inside node-exist was considered and left out on purpose, so the library does not grow a workaround for a flag that may be removed.

## Testing

Locally, Node.js 24.10.0:

| eXist-db | tests | pass | fail | todo |
|---|---|---|---|---|
| 7.0.0-SNAPSHOT (`latest`, sha256:8c181a…) | 95 | 89 | 0 | 6 |
| 6.4.0 | 95 | 95 | 0 | 0 |

## Notes

- `release` currently resolves to 7.0.0-beta3 (the Docker Hub tag moved on 2026-06-02), which fails six of the same tests. Because the gate is on the major version, those cells will probably turn green as a side effect.
- Independent of #400 (undici 8, timeouts): the branches touch different parts of the specs and rebase onto each other cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bdrW9vpnvJkeBtS1UZ92E
