### PR TITLE
fix(rest): do not reuse connections after streamed uploads to eXist-db 4

### DIFF
--- a/rest/verbs.js
+++ b/rest/verbs.js
@@ -17,6 +17,49 @@ function normalizeDBPath (path) {
   return path.startsWith('/') ? path.substring(1) : path
 }
 
+const serverMajorVersions = new WeakMap()
+
+/**
+ * major version of the eXist-db instance a client is connected to,
+ * asked for once per client
+ * @param {Client} client undici.Client instance
+ * @returns {Promise<number>} major version, NaN if it could not be determined
+ */
+function serverMajorVersion (client) {
+  if (!serverMajorVersions.has(client)) {
+    const query = new URLSearchParams({ _query: 'system:get-version()', _wrap: 'no' })
+    const majorVersion = client.request({ method: 'GET', path: `db?${query}` })
+      .then(response => response.body.text())
+      .then(version => parseInt(version, 10))
+      .catch(() => NaN)
+    serverMajorVersions.set(client, majorVersion)
+  }
+  return serverMajorVersions.get(client)
+}
+
+/**
+ * undici interceptor closing the connection once the response was received
+ */
+const closeConnectionAfterResponse = dispatch => (opts, handler) => dispatch({ ...opts, reset: true }, handler)
+
+/**
+ * eXist-db 4 (Jetty 9.4.14) can close a connection right after it answered a
+ * streamed upload, without announcing it. The next request on that connection
+ * would fail with "other side closed". Streamed uploads to eXist-db 4 therefore
+ * close their connection, later versions keep reusing it.
+ * @param {Client} client undici.Client instance
+ * @param {any} body contents of the resource
+ * @returns {Promise<Client>} the client to send the upload with
+ */
+async function uploadClient (client, body) {
+  const knownLength = typeof body === 'string' || ArrayBuffer.isView(body) || body instanceof ArrayBuffer
+  if (knownLength) {
+    return client
+  }
+  const majorVersion = await serverMajorVersion(client)
+  return majorVersion < 5 ? client.compose(closeConnectionAfterResponse) : client
+}
+
 /**
  * create resource in DB
  * @param {Client} client undici.Client instance
@@ -27,6 +70,7 @@ function normalizeDBPath (path) {
  */
 async function put (client, body, rawPath, mimetype) {
   const path = normalizeDBPath(rawPath)
+  client = await uploadClient(client, body)
   const headers = {
     'content-type': getMimeType(rawPath, mimetype)
   }

--- a/spec/tests/rest-streamed-upload.js
+++ b/spec/tests/rest-streamed-upload.js
@@ -1,0 +1,72 @@
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert'
+import dc from 'node:diagnostics_channel'
+import { createReadStream, readFileSync } from 'node:fs'
+import { getRestClient, getXmlRpcClient } from '../../index.js'
+import { envOptions } from '../connection.js'
+
+// eXist-db 4 (Jetty 9.4.14) can close a connection right after it answered a
+// streamed upload, without announcing it. The next request on that connection
+// then fails with "other side closed". Streamed uploads to eXist-db 4 must not
+// leave their connection open, later versions keep reusing connections.
+await describe('connections after streamed uploads', async () => {
+  const collection = 'db/rest-stream-test'
+  const db = getXmlRpcClient(envOptions)
+  const major = parseInt(await db.server.version(), 10)
+
+  const requests = []
+  const recordRequest = ({ request, socket }) => {
+    requests.push({ method: request.method, path: request.path, socket })
+  }
+  dc.subscribe('undici:client:sendHeaders', recordRequest)
+  after(() => dc.unsubscribe('undici:client:sendHeaders', recordRequest))
+
+  const isVersionQuery = request => request.path.includes('get-version')
+  const isForCollection = request => request.path.includes(collection)
+  const generator = function * () {
+    yield 'streamed\n'
+  }
+
+  await it('does not ask for the server version for uploads of known length', async () => {
+    const rc = getRestClient(envOptions)
+    requests.length = 0
+    await rc.put(readFileSync('spec/files/test.xml'), `${collection}/from-buffer.xml`)
+    await rc.put('<from-string/>', `${collection}/from-string.xml`)
+    assert.strictEqual(requests.filter(isVersionQuery).length, 0)
+  })
+
+  await it('asks for the server version once per client for streamed uploads', async () => {
+    const rc = getRestClient(envOptions)
+    requests.length = 0
+    await rc.put(createReadStream('spec/files/test.xml'), `${collection}/from-stream.xml`)
+    await rc.put(generator, `${collection}/from-generator.txt`)
+    assert.strictEqual(requests.filter(isVersionQuery).length, 1)
+  })
+
+  const expectation = major < 5
+    ? 'opens a new connection after a streamed upload to eXist-db 4'
+    : 'reuses the connection after a streamed upload'
+
+  await it(expectation, async () => {
+    const rc = getRestClient(envOptions)
+    // the first streamed upload of a client also asks for the server version
+    await rc.put(generator, `${collection}/warm-up.txt`)
+    requests.length = 0
+
+    await rc.put(createReadStream('spec/files/test.xml'), `${collection}/reuse.xml`)
+    await rc.get(`${collection}/reuse.xml`)
+
+    const [upload, read] = requests.filter(isForCollection)
+    assert.strictEqual(upload.method, 'PUT')
+    assert.strictEqual(read.method, 'GET')
+    if (major < 5) {
+      assert.notStrictEqual(read.socket, upload.socket, 'connection was reused')
+    } else {
+      assert.strictEqual(read.socket, upload.socket, 'connection was not reused')
+    }
+  })
+
+  await it('teardown', async () => {
+    await db.collections.remove(`/${collection}`)
+  })
+})


### PR DESCRIPTION
Fixes the flaky eXist-db 4.10.0 cells: `create file from Generator returns Created` fails with `SocketError: other side closed`, followed by three knock-on failures (`post honors start and max`, `post honors just start`, `post honors cache` count 6 resources instead of 7 because the generator file is missing).

## The flake

Seen with the same signature on the 4.10.0 cells of #393, #394, #395, #397 and #402 (and #391, logs expired), on Node.js 20, 22 and 24 alike, never on 5.4.1 or later.

- The failing request runs on a **reused** keep-alive connection (`bytesRead: 847` on the socket in the error).
- The request before it is `upload invalid file (stream) fails with Bad Request`, a chunked PUT that eXist-db 4.10.0 (Jetty 9.4.14) answers with `400 Parsing exception: …`, `Content-Length: 0` and no `Connection: close`.
- undici reuses a connection one event loop turn after the response, provided the request body was fully written (if the response arrives while still writing, it discards the socket itself). If the server closes the connection just after that, the next request fails with `other side closed`.

It does not reproduce locally (the 4.10.0 image runs emulated on arm64, far slower than in CI): 10 runs of `rest.js`, 100 invalid-stream/generator pairs on one connection and variants with a delayed stream end all passed, and eXist-db never closed the connection. The most likely explanation is a timing window in CI in which Jetty completes the 400 before it has read the end of the chunked body and then drops the connection. So only repeated CI runs can confirm this fix.

## The fix

`put` in `rest/verbs.js`:

- uploads of known length (strings, Buffers and typed arrays, ArrayBuffers) take the same path as before
- for streams and generators the client asks the server for its version once, via `db?_query=system:get-version()&_wrap=no`, and caches the answer per client
- eXist-db **4**: the upload is sent with undici's `reset: true`, so its connection closes after the response and the next request opens a new one
- eXist-db **5 and later**, or a version that cannot be determined: connections keep being reused

The cost for recent versions is one small GET per REST client, only on its first streamed upload. The option is added by an interceptor, the request calls in `put` are unchanged.

## Testing

New `spec/tests/rest-streamed-upload.js` (red before the fix on 6.4.0 and 4.10.0). It observes `undici:client:sendHeaders` and checks that

- uploads of known length do not ask for the version
- a stream and a generator upload ask for it exactly once
- after a streamed upload eXist-db 4 gets a new connection, 5 and later reuse it

Locally, Node.js 24.10.0:

| eXist-db | tests | pass | fail |
|---|---|---|---|
| 4.10.0 | 99 | 99 | 0 |
| 6.4.0 | 99 | 99 | 0 |
| 7.0.0-SNAPSHOT (`latest`) | 99 | 92 | 7 |

The seven failures on `latest` are the eXist-db 7 changes handled in #402. The new spec passes on all three.

## Notes

- Merges cleanly with #400 (undici 8) and #402 (eXist-db 7 tests), checked with `git merge-tree`. undici 8 publishes `undici:client:sendHeaders` for HTTP/2 as well, so the spec keeps working there.
- Please re-run the 4.10.0 cells a few times before drawing conclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bdrW9vpnvJkeBtS1UZ92E
